### PR TITLE
Bugs and Units

### DIFF
--- a/src/SourceCode.Chasm.IO.Bond.Tests/NodeFixtures.cs
+++ b/src/SourceCode.Chasm.IO.Bond.Tests/NodeFixtures.cs
@@ -7,10 +7,24 @@ namespace SourceCode.Chasm.IO.Bond.Tests
         private static readonly IChasmSerializer _serializer = new BondChasmSerializer();
 
         [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(BondCasSerializer_WriteRead_NullTreeNodeList))]
+        public static void BondCasSerializer_WriteRead_NullTreeNodeList()
+        {
+            var expected = new TreeNodeList();
+
+            using (var seg = _serializer.Serialize(expected))
+            {
+                var actual = _serializer.DeserializeTree(seg.Result);
+
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(BondCasSerializer_WriteRead_EmptyTreeNodeList))]
         public static void BondCasSerializer_WriteRead_EmptyTreeNodeList()
         {
-            var expected = new TreeNodeList();
+            var expected = new TreeNodeList(new TreeNode[0]);
 
             using (var seg = _serializer.Serialize(expected))
             {

--- a/src/SourceCode.Chasm.IO.Json.Tests/NodeFixtures.cs
+++ b/src/SourceCode.Chasm.IO.Json.Tests/NodeFixtures.cs
@@ -7,10 +7,24 @@ namespace SourceCode.Chasm.IO.Json.Tests
         private static readonly ChasmSerializer _serializer = new JsonChasmSerializer();
 
         [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(JsonCasSerializer_WriteRead_NullTreeNodeList))]
+        public static void JsonCasSerializer_WriteRead_NullTreeNodeList()
+        {
+            var expected = new TreeNodeList();
+
+            using (var seg = _serializer.Serialize(expected))
+            {
+                var actual = _serializer.DeserializeTree(seg.Result);
+
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(JsonCasSerializer_WriteRead_EmptyTreeNodeList))]
         public static void JsonCasSerializer_WriteRead_EmptyTreeNodeList()
         {
-            var expected = new TreeNodeList();
+            var expected = new TreeNodeList(new TreeNode[0]);
 
             using (var seg = _serializer.Serialize(expected))
             {

--- a/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
+++ b/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.0.3347">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00129" />
+    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00131" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm.IO.Proto.Tests/NodeFixtures.cs
+++ b/src/SourceCode.Chasm.IO.Proto.Tests/NodeFixtures.cs
@@ -7,10 +7,24 @@ namespace SourceCode.Chasm.IO.Proto.Tests
         private static readonly IChasmSerializer _serializer = new ProtoCasSerializer();
 
         [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ProtoCasSerializer_WriteRead_NullTreeNodeList))]
+        public static void ProtoCasSerializer_WriteRead_NullTreeNodeList()
+        {
+            var expected = new TreeNodeList();
+
+            using (var seg = _serializer.Serialize(expected))
+            {
+                var actual = _serializer.DeserializeTree(seg.Result);
+
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(ProtoCasSerializer_WriteRead_EmptyTreeNodeList))]
         public static void ProtoCasSerializer_WriteRead_EmptyTreeNodeList()
         {
-            var expected = new TreeNodeList();
+            var expected = new TreeNodeList(new TreeNode[0]);
 
             using (var seg = _serializer.Serialize(expected))
             {

--- a/src/SourceCode.Chasm.Tests/BlobIdTests.cs
+++ b/src/SourceCode.Chasm.Tests/BlobIdTests.cs
@@ -1,0 +1,27 @@
+﻿using Xunit;
+
+namespace SourceCode.Chasm.Tests
+{
+    public static class BlobIdTests
+    {
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(BlobId_has_empty_sha1))]
+        public static void BlobId_has_empty_sha1()
+        {
+            Assert.Equal(Sha1.Empty, BlobId.Empty.Sha1);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(BlobId_equality))]
+        public static void BlobId_equality()
+        {
+            var blobId1 = new BlobId(Sha1.Hash("abc"));
+            var blobId2 = new BlobId(Sha1.Hash("abc"));
+            var blobId3 = new BlobId(Sha1.Hash("def"));
+
+            Assert.Equal(blobId1, blobId2);
+            Assert.NotEqual(BlobId.Empty, blobId1);
+            Assert.NotEqual(blobId3, blobId1);
+        }
+    }
+}

--- a/src/SourceCode.Chasm.Tests/BlobIdTests.cs
+++ b/src/SourceCode.Chasm.Tests/BlobIdTests.cs
@@ -21,8 +21,13 @@ namespace SourceCode.Chasm.Tests
             var blobId3 = new BlobId(Sha1.Hash("def"));
 
             Assert.Equal(blobId1, blobId2);
+            Assert.Equal(blobId1.GetHashCode(), blobId2.GetHashCode());
+
             Assert.NotEqual(BlobId.Empty, blobId1);
+            Assert.NotEqual(BlobId.Empty.GetHashCode(), blobId1.GetHashCode());
+
             Assert.NotEqual(blobId3, blobId1);
+            Assert.NotEqual(blobId3.GetHashCode(), blobId1.GetHashCode());
         }
     }
 }

--- a/src/SourceCode.Chasm.Tests/BlobIdTests.cs
+++ b/src/SourceCode.Chasm.Tests/BlobIdTests.cs
@@ -9,6 +9,7 @@ namespace SourceCode.Chasm.Tests
         public static void BlobId_has_empty_sha1()
         {
             Assert.Equal(Sha1.Empty, BlobId.Empty.Sha1);
+            Assert.Equal(default, BlobId.Empty);
         }
 
         [Trait("Type", "Unit")]

--- a/src/SourceCode.Chasm.Tests/BlobTests.cs
+++ b/src/SourceCode.Chasm.Tests/BlobTests.cs
@@ -18,8 +18,15 @@ namespace SourceCode.Chasm.Tests
             Assert.Null(noData.Data);
 
             Assert.Equal(noData, nullData);
+            Assert.Equal(noData.GetHashCode(), nullData.GetHashCode());
+
             Assert.Equal(Blob.Empty, noData);
+            Assert.Equal(Blob.Empty.GetHashCode(), noData.GetHashCode());
+
             Assert.Equal(Blob.Empty, nullData);
+            Assert.Equal(Blob.Empty.GetHashCode(), nullData.GetHashCode());
+
+            // null and [] both have same hash
             Assert.NotEqual(Blob.Empty, emptyData);
             Assert.NotEqual(noData, emptyData);
         }

--- a/src/SourceCode.Chasm.Tests/BlobTests.cs
+++ b/src/SourceCode.Chasm.Tests/BlobTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Xunit;
+
+namespace SourceCode.Chasm.Tests
+{
+    public static class BlobTests
+    {
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(Blob_is_empty))]
+        public static void Blob_is_empty()
+        {
+            var noData = new Blob();
+            var nullData = new Blob(null);
+            var emptyData = new Blob(Array.Empty<byte>());
+
+            Assert.Null(Blob.Empty.Data);
+            Assert.Null(nullData.Data);
+            Assert.Null(noData.Data);
+
+            Assert.Equal(noData, nullData);
+            Assert.Equal(Blob.Empty, noData);
+            Assert.Equal(Blob.Empty, nullData);
+            Assert.NotEqual(Blob.Empty, emptyData);
+            Assert.NotEqual(noData, emptyData);
+        }
+
+        [InlineData(null, null, true)]
+        [InlineData(new byte[0], null, false)]
+        [InlineData(new byte[0], new byte[0], true)]
+        [InlineData(new byte[0], new byte[1] { 0 }, false)]
+        [InlineData(new byte[1] { 0 }, new byte[1] { 0 }, true)]
+        [InlineData(new byte[1] { 0 }, new byte[1] { 1 }, false)]
+        [InlineData(new byte[1] { 0 }, new byte[2] { 0, 1 }, false)]
+        [InlineData(new byte[2] { 0, 0 }, new byte[2] { 0, 1 }, false)]
+        [InlineData(new byte[2] { 0, 1 }, new byte[2] { 0, 1 }, true)]
+        [Trait("Type", "Unit")]
+        [Theory(DisplayName = nameof(Blob_equality))]
+        public static void Blob_equality(byte[] x, byte[] y, bool isEqual)
+        {
+            Assert.Equal(isEqual, new Blob(x) == new Blob(y));
+        }
+    }
+}

--- a/src/SourceCode.Chasm.Tests/CommitIdTests.cs
+++ b/src/SourceCode.Chasm.Tests/CommitIdTests.cs
@@ -9,6 +9,7 @@ namespace SourceCode.Chasm.Tests
         public static void CommitId_has_empty_sha1()
         {
             Assert.Equal(Sha1.Empty, CommitId.Empty.Sha1);
+            Assert.Equal(default, CommitId.Empty);
         }
 
         [Trait("Type", "Unit")]

--- a/src/SourceCode.Chasm.Tests/CommitIdTests.cs
+++ b/src/SourceCode.Chasm.Tests/CommitIdTests.cs
@@ -21,8 +21,13 @@ namespace SourceCode.Chasm.Tests
             var commitId3 = new CommitId(Sha1.Hash("def"));
 
             Assert.Equal(commitId1, commitId2);
+            Assert.Equal(commitId1.GetHashCode(), commitId2.GetHashCode());
+
             Assert.NotEqual(CommitId.Empty, commitId1);
+            Assert.NotEqual(CommitId.Empty.GetHashCode(), commitId1.GetHashCode());
+
             Assert.NotEqual(commitId3, commitId1);
+            Assert.NotEqual(commitId3.GetHashCode(), commitId1.GetHashCode());
         }
     }
 }

--- a/src/SourceCode.Chasm.Tests/CommitIdTests.cs
+++ b/src/SourceCode.Chasm.Tests/CommitIdTests.cs
@@ -1,0 +1,27 @@
+﻿using Xunit;
+
+namespace SourceCode.Chasm.Tests
+{
+    public static class CommitIdTests
+    {
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(CommitId_has_empty_sha1))]
+        public static void CommitId_has_empty_sha1()
+        {
+            Assert.Equal(Sha1.Empty, CommitId.Empty.Sha1);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(CommitId_equality))]
+        public static void CommitId_equality()
+        {
+            var commitId1 = new CommitId(Sha1.Hash("abc"));
+            var commitId2 = new CommitId(Sha1.Hash("abc"));
+            var commitId3 = new CommitId(Sha1.Hash("def"));
+
+            Assert.Equal(commitId1, commitId2);
+            Assert.NotEqual(CommitId.Empty, commitId1);
+            Assert.NotEqual(commitId3, commitId1);
+        }
+    }
+}

--- a/src/SourceCode.Chasm.Tests/CommitRefTests.cs
+++ b/src/SourceCode.Chasm.Tests/CommitRefTests.cs
@@ -1,0 +1,27 @@
+﻿using Xunit;
+
+namespace SourceCode.Chasm.Tests
+{
+    public static class CommitIRefTests
+    {
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(CommitRef_has_empty_commitId))]
+        public static void CommitRef_has_empty_commitId()
+        {
+            Assert.Equal(CommitId.Empty, CommitRef.Empty.CommitId);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(CommitRef_equality))]
+        public static void CommitRef_equality()
+        {
+            var commitRef1 = new CommitRef(new CommitId(Sha1.Hash("abc")));
+            var commitRef2 = new CommitRef(new CommitId(Sha1.Hash("abc")));
+            var commitRef3 = new CommitRef(new CommitId(Sha1.Hash("def")));
+
+            Assert.Equal(commitRef1, commitRef2);
+            Assert.NotEqual(CommitRef.Empty, commitRef1);
+            Assert.NotEqual(commitRef3, commitRef1);
+        }
+    }
+}

--- a/src/SourceCode.Chasm.Tests/CommitRefTests.cs
+++ b/src/SourceCode.Chasm.Tests/CommitRefTests.cs
@@ -21,8 +21,13 @@ namespace SourceCode.Chasm.Tests
             var commitRef3 = new CommitRef(new CommitId(Sha1.Hash("def")));
 
             Assert.Equal(commitRef1, commitRef2);
+            Assert.Equal(commitRef1.GetHashCode(), commitRef2.GetHashCode());
+
             Assert.NotEqual(CommitRef.Empty, commitRef1);
+            Assert.NotEqual(CommitRef.Empty.GetHashCode(), commitRef1.GetHashCode());
+
             Assert.NotEqual(commitRef3, commitRef1);
+            Assert.NotEqual(commitRef3.GetHashCode(), commitRef1.GetHashCode());
         }
     }
 }

--- a/src/SourceCode.Chasm.Tests/CommitRefTests.cs
+++ b/src/SourceCode.Chasm.Tests/CommitRefTests.cs
@@ -9,6 +9,7 @@ namespace SourceCode.Chasm.Tests
         public static void CommitRef_has_empty_commitId()
         {
             Assert.Equal(CommitId.Empty, CommitRef.Empty.CommitId);
+            Assert.Equal(default, CommitRef.Empty);
         }
 
         [Trait("Type", "Unit")]

--- a/src/SourceCode.Chasm.Tests/CommitTests.cs
+++ b/src/SourceCode.Chasm.Tests/CommitTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Xunit;
+
+namespace SourceCode.Chasm.Tests
+{
+    public static class CommitTests
+    {
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(Commit_is_empty))]
+        public static void Commit_is_empty()
+        {
+            var noData = new Commit();
+            var nullData = new Commit(null, TreeId.Empty, default, null);
+
+            // Parents
+            Assert.Null(Commit.Empty.Parents);
+            Assert.Null(noData.Parents);
+            Assert.Null(nullData.Parents);
+
+            // TreeId
+            Assert.Equal(TreeId.Empty, Commit.Empty.TreeId);
+            Assert.Equal(TreeId.Empty, noData.TreeId);
+            Assert.Equal(TreeId.Empty, nullData.TreeId);
+
+            // DateTime
+            Assert.Equal(default, Commit.Empty.CommitUtc);
+            Assert.Equal(default, noData.CommitUtc);
+            Assert.Equal(default, nullData.CommitUtc);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Commit(null, TreeId.Empty, DateTime.Now, null));
+
+            // Message
+            Assert.Null(Commit.Empty.CommitMessage);
+            Assert.Null(noData.CommitMessage);
+            Assert.Null(nullData.CommitMessage);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(Commit_equality))]
+        public static void Commit_equality()
+        {
+            var expected = new Commit(new[] { new CommitId(Sha1.Hash("c1")), new CommitId(Sha1.Hash("c2")) }, new TreeId(Sha1.Hash("abc")), DateTime.UtcNow, "hello");
+
+            // Equal
+            var actual = new Commit(expected.Parents, expected.TreeId, expected.CommitUtc, expected.CommitMessage);
+            Assert.Equal(expected, actual);
+
+            // Parents
+            actual = new Commit(null, expected.TreeId, expected.CommitUtc, expected.CommitMessage);
+            Assert.NotEqual(expected, actual);
+
+            actual = new Commit(Array.Empty<CommitId>(), expected.TreeId, expected.CommitUtc, expected.CommitMessage.ToUpperInvariant());
+            Assert.NotEqual(expected, actual);
+
+            actual = new Commit(Commit.Orphaned, expected.TreeId, expected.CommitUtc, expected.CommitMessage.ToUpperInvariant());
+            Assert.NotEqual(expected, actual);
+
+            actual = new Commit(new[] { expected.Parents[0] }, expected.TreeId, expected.CommitUtc, expected.CommitMessage.ToUpperInvariant());
+            Assert.NotEqual(expected, actual);
+
+            actual = new Commit(new[] { expected.Parents[0], expected.Parents[1], new CommitId(Sha1.Hash("c3")) }, expected.TreeId, expected.CommitUtc, expected.CommitMessage.ToUpperInvariant());
+            Assert.NotEqual(expected, actual);
+
+            // TreeId
+            actual = new Commit(expected.Parents, TreeId.Empty, expected.CommitUtc, expected.CommitMessage);
+            Assert.NotEqual(expected, actual);
+
+            actual = new Commit(expected.Parents, new TreeId(Sha1.Hash("def")), expected.CommitUtc, expected.CommitMessage);
+            Assert.NotEqual(expected, actual);
+
+            // DateTime
+            actual = new Commit(expected.Parents, expected.TreeId, default, expected.CommitMessage);
+            Assert.NotEqual(expected, actual);
+
+            actual = new Commit(expected.Parents, expected.TreeId, DateTime.MaxValue.ToUniversalTime(), expected.CommitMessage);
+            Assert.NotEqual(expected, actual);
+
+            actual = new Commit(expected.Parents, expected.TreeId, expected.CommitUtc.AddTicks(1), expected.CommitMessage);
+            Assert.NotEqual(expected, actual);
+
+            // Message
+            actual = new Commit(expected.Parents, expected.TreeId, expected.CommitUtc, null);
+            Assert.NotEqual(expected, actual);
+
+            actual = new Commit(expected.Parents, expected.TreeId, expected.CommitUtc, expected.CommitMessage.ToUpperInvariant());
+            Assert.NotEqual(expected, actual);
+        }
+    }
+}

--- a/src/SourceCode.Chasm.Tests/CommitTests.cs
+++ b/src/SourceCode.Chasm.Tests/CommitTests.cs
@@ -43,46 +43,58 @@ namespace SourceCode.Chasm.Tests
             // Equal
             var actual = new Commit(expected.Parents, expected.TreeId, expected.CommitUtc, expected.CommitMessage);
             Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
 
             // Parents
             actual = new Commit(null, expected.TreeId, expected.CommitUtc, expected.CommitMessage);
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             actual = new Commit(Array.Empty<CommitId>(), expected.TreeId, expected.CommitUtc, expected.CommitMessage.ToUpperInvariant());
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             actual = new Commit(Commit.Orphaned, expected.TreeId, expected.CommitUtc, expected.CommitMessage.ToUpperInvariant());
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             actual = new Commit(new[] { expected.Parents[0] }, expected.TreeId, expected.CommitUtc, expected.CommitMessage.ToUpperInvariant());
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             actual = new Commit(new[] { expected.Parents[0], expected.Parents[1], new CommitId(Sha1.Hash("c3")) }, expected.TreeId, expected.CommitUtc, expected.CommitMessage.ToUpperInvariant());
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             // TreeId
             actual = new Commit(expected.Parents, TreeId.Empty, expected.CommitUtc, expected.CommitMessage);
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             actual = new Commit(expected.Parents, new TreeId(Sha1.Hash("def")), expected.CommitUtc, expected.CommitMessage);
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             // DateTime
             actual = new Commit(expected.Parents, expected.TreeId, default, expected.CommitMessage);
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             actual = new Commit(expected.Parents, expected.TreeId, DateTime.MaxValue.ToUniversalTime(), expected.CommitMessage);
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             actual = new Commit(expected.Parents, expected.TreeId, expected.CommitUtc.AddTicks(1), expected.CommitMessage);
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             // Message
             actual = new Commit(expected.Parents, expected.TreeId, expected.CommitUtc, null);
             Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
 
             actual = new Commit(expected.Parents, expected.TreeId, expected.CommitUtc, expected.CommitMessage.ToUpperInvariant());
-            Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected, actual); // hashcode is the same for upper/lower string
         }
     }
 }

--- a/src/SourceCode.Chasm.Tests/Sha1Tests.cs
+++ b/src/SourceCode.Chasm.Tests/Sha1Tests.cs
@@ -2,7 +2,7 @@
 using System.Text;
 using Xunit;
 
-namespace SourceCode.Chasm.Units
+namespace SourceCode.Chasm.Tests
 {
     public static class Sha1Tests
     {

--- a/src/SourceCode.Chasm.Tests/Sha1Tests.cs
+++ b/src/SourceCode.Chasm.Tests/Sha1Tests.cs
@@ -11,6 +11,7 @@ namespace SourceCode.Chasm.Tests
         public static void When_create_empty_sha1()
         {
             var expected = Sha1.Empty;
+            Assert.Equal(default, expected);
 
             // Null string
             var actual = Sha1.Hash((string)null);

--- a/src/SourceCode.Chasm.Tests/TreeIdTests.cs
+++ b/src/SourceCode.Chasm.Tests/TreeIdTests.cs
@@ -9,6 +9,7 @@ namespace SourceCode.Chasm.Tests
         public static void TreeId_has_empty_sha1()
         {
             Assert.Equal(Sha1.Empty, TreeId.Empty.Sha1);
+            Assert.Equal(default, TreeId.Empty);
         }
 
         [Trait("Type", "Unit")]

--- a/src/SourceCode.Chasm.Tests/TreeIdTests.cs
+++ b/src/SourceCode.Chasm.Tests/TreeIdTests.cs
@@ -1,0 +1,27 @@
+﻿using Xunit;
+
+namespace SourceCode.Chasm.Tests
+{
+    public static class TreeIdTests
+    {
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeId_has_empty_sha1))]
+        public static void TreeId_has_empty_sha1()
+        {
+            Assert.Equal(Sha1.Empty, TreeId.Empty.Sha1);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeId_equality))]
+        public static void TreeId_equality()
+        {
+            var treeId1 = new TreeId(Sha1.Hash("abc"));
+            var treeId2 = new TreeId(Sha1.Hash("abc"));
+            var treeId3 = new TreeId(Sha1.Hash("def"));
+
+            Assert.Equal(treeId1, treeId2);
+            Assert.NotEqual(TreeId.Empty, treeId1);
+            Assert.NotEqual(treeId3, treeId1);
+        }
+    }
+}

--- a/src/SourceCode.Chasm.Tests/TreeIdTests.cs
+++ b/src/SourceCode.Chasm.Tests/TreeIdTests.cs
@@ -21,8 +21,13 @@ namespace SourceCode.Chasm.Tests
             var treeId3 = new TreeId(Sha1.Hash("def"));
 
             Assert.Equal(treeId1, treeId2);
+            Assert.Equal(treeId1.GetHashCode(), treeId2.GetHashCode());
+
             Assert.NotEqual(TreeId.Empty, treeId1);
+            Assert.NotEqual(TreeId.Empty.GetHashCode(), treeId1.GetHashCode());
+
             Assert.NotEqual(treeId3, treeId1);
+            Assert.NotEqual(treeId3.GetHashCode(), treeId1.GetHashCode());
         }
     }
 }

--- a/src/SourceCode.Chasm.Tests/TreeNodeListTests.cs
+++ b/src/SourceCode.Chasm.Tests/TreeNodeListTests.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Chasm.Tests
             var nullData = new TreeNodeList(null);
             var emptyData = new TreeNodeList(Array.Empty<TreeNode>());
 
-            Assert.Equal(0, TreeNodeList.Empty.Count);
+            Assert.Empty(TreeNodeList.Empty);
 
             Assert.Equal(noData, nullData);
             Assert.Equal(noData.GetHashCode(), nullData.GetHashCode());
@@ -25,9 +25,38 @@ namespace SourceCode.Chasm.Tests
             Assert.Equal(TreeNodeList.Empty, nullData);
             Assert.Equal(TreeNodeList.Empty.GetHashCode(), nullData.GetHashCode());
 
-            // null and [] both have same hash
-            Assert.NotEqual(TreeNodeList.Empty, emptyData);
-            Assert.NotEqual(noData, emptyData);
+            Assert.Equal(TreeNodeList.Empty, emptyData); // By design; see ctor
+            Assert.Equal(TreeNodeList.Empty.GetHashCode(), emptyData.GetHashCode());
+
+            Assert.Equal(noData, emptyData); // By design; see ctor
+            Assert.Equal(noData.GetHashCode(), emptyData.GetHashCode());
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeNodeList_equality))]
+        public static void TreeNodeList_equality()
+        {
+            var expected = new TreeNodeList(new[] { new TreeNode("c1", NodeKind.Blob, Sha1.Hash("c1")), new TreeNode("c2", NodeKind.Tree, Sha1.Hash("c2")) });
+            var node3 = new TreeNode("c3", NodeKind.Tree, Sha1.Hash("c3"));
+
+            // Equal
+            var actual = new TreeNodeList().Merge(expected);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Less Nodes
+            actual = new TreeNodeList().Merge(expected[0]);
+            Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
+
+            // More Nodes
+            actual = new TreeNodeList().Merge(expected).Merge(node3);
+            Assert.NotEqual(expected, actual);
+            Assert.NotEqual(expected.GetHashCode(), actual.GetHashCode());
+
+            // Different Nodes
+            actual = new TreeNodeList().Merge(expected[0]).Merge(node3);
+            Assert.NotEqual(expected, actual); // hashcode is the same (node count)
         }
 
         [Trait("Type", "Unit")]

--- a/src/SourceCode.Chasm.Tests/TreeNodeListTests.cs
+++ b/src/SourceCode.Chasm.Tests/TreeNodeListTests.cs
@@ -7,6 +7,30 @@ namespace SourceCode.Chasm.Tests
     public static class TreeNodeListTests
     {
         [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeNodeList_is_empty))]
+        public static void TreeNodeList_is_empty()
+        {
+            var noData = new TreeNodeList();
+            var nullData = new TreeNodeList(null);
+            var emptyData = new TreeNodeList(Array.Empty<TreeNode>());
+
+            Assert.Equal(0, TreeNodeList.Empty.Count);
+
+            Assert.Equal(noData, nullData);
+            Assert.Equal(noData.GetHashCode(), nullData.GetHashCode());
+
+            Assert.Equal(TreeNodeList.Empty, noData);
+            Assert.Equal(TreeNodeList.Empty.GetHashCode(), noData.GetHashCode());
+
+            Assert.Equal(TreeNodeList.Empty, nullData);
+            Assert.Equal(TreeNodeList.Empty.GetHashCode(), nullData.GetHashCode());
+
+            // null and [] both have same hash
+            Assert.NotEqual(TreeNodeList.Empty, emptyData);
+            Assert.NotEqual(noData, emptyData);
+        }
+
+        [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(TreeNodeList_Merge_Single))]
         public static void TreeNodeList_Merge_Single()
         {

--- a/src/SourceCode.Chasm.Tests/TreeNodeTests.cs
+++ b/src/SourceCode.Chasm.Tests/TreeNodeTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Xunit;
+
+namespace SourceCode.Chasm.Tests
+{
+    public static class TreeNodeTests
+    {
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeNode_is_empty))]
+        public static void TreeNode_is_empty()
+        {
+            var noData = new TreeNode();
+            var nullData = new TreeNode("a", NodeKind.None, Sha1.Empty);
+
+            Assert.Equal(default, TreeNode.Empty);
+
+            // Name
+            Assert.Null(TreeNode.Empty.Name);
+            Assert.Null(TreeNode.EmptyBlob.Name);
+            Assert.Null(TreeNode.EmptyTree.Name);
+            Assert.Null(noData.Name);
+            Assert.Equal("a", nullData.Name);
+            Assert.Throws<ArgumentNullException>(() => new TreeNode(null, NodeKind.None, Sha1.Empty));
+            Assert.Throws<ArgumentNullException>(() => new TreeNode(null, BlobId.Empty));
+            Assert.Throws<ArgumentNullException>(() => new TreeNode(null, TreeId.Empty));
+
+            // NodeKind
+            Assert.Equal(NodeKind.None, default);
+            Assert.Equal(default, TreeNode.Empty.Kind);
+            Assert.Equal(default, noData.Kind);
+            Assert.Equal(default, nullData.Kind);
+            Assert.Equal(NodeKind.Blob, TreeNode.EmptyBlob.Kind);
+            Assert.Equal(NodeKind.Tree, TreeNode.EmptyTree.Kind);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new TreeNode("a", (NodeKind)4, Sha1.Empty));
+
+            // Sha1
+            Assert.Equal(default, TreeNode.Empty.Sha1);
+            Assert.Equal(default, TreeNode.EmptyBlob.Sha1);
+            Assert.Equal(default, TreeNode.EmptyTree.Sha1);
+            Assert.Equal(default, noData.Sha1);
+            Assert.Equal(default, nullData.Sha1);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeNode_equality))]
+        public static void TreeNode_equality()
+        {
+            var expected = new TreeNode("a", NodeKind.Blob, Sha1.Hash("abc"));
+
+            // Equal
+            var actual = new TreeNode(expected.Name, expected.Kind, expected.Sha1);
+            Assert.Equal(expected, actual);
+
+            // Name
+            actual = new TreeNode("b", expected.Kind, expected.Sha1);
+            Assert.NotEqual(expected, actual);
+
+            actual = new TreeNode("ab", expected.Kind, expected.Sha1);
+            Assert.NotEqual(expected, actual);
+
+            actual = new TreeNode(expected.Name.ToUpperInvariant(), expected.Kind, expected.Sha1);
+            Assert.NotEqual(expected, actual);
+
+            // Kind
+            actual = new TreeNode(expected.Name, default, expected.Sha1);
+            Assert.NotEqual(expected, actual);
+
+            actual = new TreeNode(expected.Name, NodeKind.Tree, expected.Sha1);
+            Assert.NotEqual(expected, actual);
+
+            // Sha1
+            actual = new TreeNode(expected.Name, expected.Kind, Sha1.Hash("def"));
+            Assert.NotEqual(expected, actual);
+        }
+    }
+}

--- a/src/SourceCode.Chasm/Blob.cs
+++ b/src/SourceCode.Chasm/Blob.cs
@@ -20,7 +20,7 @@ namespace SourceCode.Chasm
 
         public Blob(byte[] data)
         {
-            Data = data ?? throw new ArgumentNullException(nameof(data));
+            Data = data;
         }
 
         public void Deconstruct(out byte[] data)
@@ -38,13 +38,19 @@ namespace SourceCode.Chasm
             if (Data == null) return true;
 
             if (Data.Length != other.Data.Length) return false;
-            if (Data.Length == 0) return true;
 
-            for (var i = 0; i < Data.Length; i++)
-                if (Data[i] != other.Data[i])
-                    return false;
-
-            return true;
+            switch (Data.Length)
+            {
+                case 0: return true;
+                case 1: return Data[0] == other.Data[0];
+                default:
+                    {
+                        for (var i = 0; i < Data.Length; i++)
+                            if (Data[i] != other.Data[i])
+                                return false;
+                        return true;
+                    }
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/SourceCode.Chasm/Blob.cs
+++ b/src/SourceCode.Chasm/Blob.cs
@@ -34,14 +34,14 @@ namespace SourceCode.Chasm
         #region IEquatable
 
         public bool Equals(Blob other)
-            => BufferComparer.Default.Equals(Data, other.Data); // Has null-handling logic
+            => BufferComparer.Default.Equals(Data, other.Data); // Callee has null-handling logic
 
         public override bool Equals(object obj)
             => obj is Blob blob
             && Equals(blob);
 
         public override int GetHashCode()
-            => Data.Length.GetHashCode();
+            => (Data?.Length ?? 0).GetHashCode();
 
         public static bool operator ==(Blob x, Blob y) => x.Equals(y);
 

--- a/src/SourceCode.Chasm/Blob.cs
+++ b/src/SourceCode.Chasm/Blob.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SourceCode.Clay.Buffers;
+using System;
 
 namespace SourceCode.Chasm
 {
@@ -33,25 +34,7 @@ namespace SourceCode.Chasm
         #region IEquatable
 
         public bool Equals(Blob other)
-        {
-            if (Data == null ^ other.Data == null) return false;
-            if (Data == null) return true;
-
-            if (Data.Length != other.Data.Length) return false;
-
-            switch (Data.Length)
-            {
-                case 0: return true;
-                case 1: return Data[0] == other.Data[0];
-                default:
-                    {
-                        for (var i = 0; i < Data.Length; i++)
-                            if (Data[i] != other.Data[i])
-                                return false;
-                        return true;
-                    }
-            }
-        }
+            => BufferComparer.Default.Equals(Data, other.Data); // Has null-handling logic
 
         public override bool Equals(object obj)
             => obj is Blob blob

--- a/src/SourceCode.Chasm/Blob.cs
+++ b/src/SourceCode.Chasm/Blob.cs
@@ -41,7 +41,7 @@ namespace SourceCode.Chasm
             && Equals(blob);
 
         public override int GetHashCode()
-            => (Data?.Length ?? 0).GetHashCode();
+            => Data == null ? 0 : Data.Length.GetHashCode();
 
         public static bool operator ==(Blob x, Blob y) => x.Equals(y);
 

--- a/src/SourceCode.Chasm/Commit.cs
+++ b/src/SourceCode.Chasm/Commit.cs
@@ -10,7 +10,7 @@ namespace SourceCode.Chasm
 
         public static Commit Empty { get; }
 
-        private static readonly CommitId[] _orphan = new[] { CommitId.Empty };
+        public static CommitId[] Orphaned { get; } = new[] { CommitId.Empty };
 
         #endregion
 
@@ -30,9 +30,9 @@ namespace SourceCode.Chasm
 
         public Commit(IReadOnlyList<CommitId> parents, TreeId treeId, DateTime commitUtc, string commitMessage)
         {
-            if (commitUtc.Kind != DateTimeKind.Utc) throw new ArgumentException(nameof(commitUtc));
+            if (commitUtc != default && commitUtc.Kind != DateTimeKind.Utc) throw new ArgumentOutOfRangeException(nameof(commitUtc));
 
-            Parents = (parents == null || parents.Count == 0) ? _orphan : parents;
+            Parents = parents;
             TreeId = treeId;
             CommitUtc = commitUtc;
             CommitMessage = commitMessage;

--- a/src/SourceCode.Chasm/Commit.cs
+++ b/src/SourceCode.Chasm/Commit.cs
@@ -57,8 +57,8 @@ namespace SourceCode.Chasm
         public bool Equals(Commit other)
         {
             if (CommitUtc != other.CommitUtc) return false;
-            if (!StringComparer.Ordinal.Equals(CommitMessage, other.CommitMessage)) return false;
             if (!TreeId.Equals(other.TreeId)) return false;
+            if (!StringComparer.Ordinal.Equals(CommitMessage, other.CommitMessage)) return false;
             if (!Parents.NullableEquals(other.Parents, CommitId.DefaultComparer, true)) return false;
 
             return true;
@@ -77,6 +77,7 @@ namespace SourceCode.Chasm
                 h = h * 7 + TreeId.GetHashCode();
                 h = h * 7 + CommitUtc.GetHashCode();
                 h = h * 7 + (Parents?.Count ?? 0);
+                h = h * 7 + (CommitMessage?.Length ?? 0);
             }
 
             return h;

--- a/src/SourceCode.Chasm/NodeKind.cs
+++ b/src/SourceCode.Chasm/NodeKind.cs
@@ -3,8 +3,7 @@
     public enum NodeKind : byte
     {
         None = 0, // Default
-        Commit = 1,
-        Tree = 2,
-        Blob = 3
+        Tree = 1,
+        Blob = 2
     }
 }

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -29,8 +29,8 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.0.3347">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00129" />
-    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00129" />
+    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00131" />
+    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00131" />
     <PackageReference Include="System.Buffers.Primitives" Version="0.1.0-e170811-6" />
   </ItemGroup>
 </Project>

--- a/src/SourceCode.Chasm/TreeNode.cs
+++ b/src/SourceCode.Chasm/TreeNode.cs
@@ -40,7 +40,7 @@ namespace SourceCode.Chasm
         public TreeNode(string name, NodeKind kind, Sha1 sha1)
             : this(name, sha1, kind)
         {
-            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
+            if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name));
             if (!Enum.IsDefined(typeof(NodeKind), kind)) throw new ArgumentOutOfRangeException(nameof(kind));
         }
 
@@ -70,6 +70,7 @@ namespace SourceCode.Chasm
         public bool Equals(TreeNode other)
         {
             if (!StringComparer.Ordinal.Equals(Name, other.Name)) return false;
+            if (Kind != other.Kind) return false;
             if (Sha1 != other.Sha1) return false;
 
             return true;

--- a/src/SourceCode.Chasm/TreeNodeList.cs
+++ b/src/SourceCode.Chasm/TreeNodeList.cs
@@ -49,13 +49,9 @@ namespace SourceCode.Chasm
 
         public TreeNodeList(params TreeNode[] nodes)
         {
-            if (nodes == null)
+            if (nodes == null || nodes.Length == 0)
             {
                 _nodes = null;
-            }
-            else if (nodes.Length == 0)
-            {
-                _nodes = Array.Empty<TreeNode>();
             }
             else
             {
@@ -72,13 +68,9 @@ namespace SourceCode.Chasm
 
         public TreeNodeList(ICollection<TreeNode> nodes)
         {
-            if (nodes == null)
+            if (nodes == null || nodes.Count == 0)
             {
                 _nodes = null;
-            }
-            else if (nodes.Count == 0)
-            {
-                _nodes = Array.Empty<TreeNode>();
             }
             else
             {

--- a/src/SourceCode.Chasm/TreeNodeList.cs
+++ b/src/SourceCode.Chasm/TreeNodeList.cs
@@ -49,9 +49,13 @@ namespace SourceCode.Chasm
 
         public TreeNodeList(params TreeNode[] nodes)
         {
-            if (nodes == null || nodes.Length == 0)
+            if (nodes == null)
             {
                 _nodes = null;
+            }
+            else if (nodes.Length == 0)
+            {
+                _nodes = Array.Empty<TreeNode>();
             }
             else
             {
@@ -68,9 +72,13 @@ namespace SourceCode.Chasm
 
         public TreeNodeList(ICollection<TreeNode> nodes)
         {
-            if (nodes == null || nodes.Count == 0)
+            if (nodes == null)
             {
                 _nodes = null;
+            }
+            else if (nodes.Count == 0)
+            {
+                _nodes = Array.Empty<TreeNode>();
             }
             else
             {
@@ -178,7 +186,6 @@ namespace SourceCode.Chasm
 
             Array.Resize(ref newArray, i);
             return newArray;
-
         }
 
         public int IndexOf(string key)


### PR DESCRIPTION
- Fixes #1 (Need better unit coverage on Chasm)
- Fixes #14 (`Commit` should allow `CommitUtc` to be `default(DateTime)` even though it's not strictly UTC)
- Fixes #15 (`TreeNode` is not checking `NodeKind` in equality comparer)
- Fixes #16 (**Breaking change** `NodeKind` does not need a `Commit` member)
- Cover Chasm with Unit Tests
- Other bugs, nuget & cleanup