### PR TITLE
Migrate to System.Memory

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" protocolVersion="3" />
     <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/" />
   </packageSources>
   <packageSourceCredentials>

--- a/src/SourceCode.Chasm.IO.Bond.Tests/CommitFixtures.cs
+++ b/src/SourceCode.Chasm.IO.Bond.Tests/CommitFixtures.cs
@@ -6,8 +6,8 @@ namespace SourceCode.Chasm.IO.Bond.Units
     public static class CommitFixtures
     {
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(BondCasSerializer_WriteRead_Commit))]
-        public static void BondCasSerializer_WriteRead_Commit()
+        [Fact(DisplayName = nameof(BondChasmSerializer_WriteRead_Commit))]
+        public static void BondChasmSerializer_WriteRead_Commit()
         {
             var ser = new BondChasmSerializer();
 

--- a/src/SourceCode.Chasm.IO.Bond.Tests/NodeFixtures.cs
+++ b/src/SourceCode.Chasm.IO.Bond.Tests/NodeFixtures.cs
@@ -7,8 +7,8 @@ namespace SourceCode.Chasm.IO.Bond.Tests
         private static readonly IChasmSerializer _serializer = new BondChasmSerializer();
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(BondCasSerializer_WriteRead_NullTreeNodeList))]
-        public static void BondCasSerializer_WriteRead_NullTreeNodeList()
+        [Fact(DisplayName = nameof(BondChasmSerializer_WriteRead_NullTreeNodeList))]
+        public static void BondChasmSerializer_WriteRead_NullTreeNodeList()
         {
             var expected = new TreeNodeList();
 
@@ -21,8 +21,8 @@ namespace SourceCode.Chasm.IO.Bond.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(BondCasSerializer_WriteRead_EmptyTreeNodeList))]
-        public static void BondCasSerializer_WriteRead_EmptyTreeNodeList()
+        [Fact(DisplayName = nameof(BondChasmSerializer_WriteRead_EmptyTreeNodeList))]
+        public static void BondChasmSerializer_WriteRead_EmptyTreeNodeList()
         {
             var expected = new TreeNodeList(new TreeNode[0]);
 
@@ -35,8 +35,8 @@ namespace SourceCode.Chasm.IO.Bond.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(BondCasSerializer_WriteRead_TreeNodeList))]
-        public static void BondCasSerializer_WriteRead_TreeNodeList()
+        [Fact(DisplayName = nameof(BondChasmSerializer_WriteRead_TreeNodeList))]
+        public static void BondChasmSerializer_WriteRead_TreeNodeList()
         {
             var expected = new TreeNodeList(new TreeNode("a", NodeKind.Blob, Sha1.Hash("abc")));
 

--- a/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Commit.cs
@@ -37,7 +37,7 @@ namespace SourceCode.Chasm.IO.Bond
 
         #region Deserialize
 
-        public override Commit DeserializeCommit(ReadOnlyBuffer<byte> buffer)
+        public override Commit DeserializeCommit(ReadOnlyMemory<byte> buffer)
         {
             var buf = new InputBuffer(buffer.ToArray()); // TODO: Perf
             var reader = new SimpleBinaryReader<InputBuffer>(buf);

--- a/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Commit.cs
@@ -37,20 +37,9 @@ namespace SourceCode.Chasm.IO.Bond
 
         #region Deserialize
 
-        public override Commit DeserializeCommit(ReadOnlyMemory<byte> buffer)
+        public override Commit DeserializeCommit(ReadOnlySpan<byte> span)
         {
-            var buf = new InputBuffer(buffer.ToArray()); // TODO: Perf
-            var reader = new SimpleBinaryReader<InputBuffer>(buf);
-
-            var wire = _commitDeserializer.Deserialize<CommitWire>(reader);
-
-            var model = wire.Convert();
-            return model;
-        }
-
-        public override Commit DeserializeCommit(ArraySegment<byte> segment)
-        {
-            var buf = new InputBuffer(segment);
+            var buf = new InputBuffer(span.ToArray()); // TODO: Perf
             var reader = new SimpleBinaryReader<InputBuffer>(buf);
 
             var wire = _commitDeserializer.Deserialize<CommitWire>(reader);

--- a/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Sha1.cs
@@ -37,7 +37,7 @@ namespace SourceCode.Chasm.IO.Bond
 
         #region Deserialize
 
-        public override Sha1 DeserializeSha1(ReadOnlyBuffer<byte> buffer)
+        public override Sha1 DeserializeSha1(ReadOnlyMemory<byte> buffer)
         {
             var buf = new InputBuffer(buffer.ToArray()); // TODO: Perf
             var reader = new SimpleBinaryReader<InputBuffer>(buf);

--- a/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Sha1.cs
@@ -37,20 +37,9 @@ namespace SourceCode.Chasm.IO.Bond
 
         #region Deserialize
 
-        public override Sha1 DeserializeSha1(ReadOnlyMemory<byte> buffer)
+        public override Sha1 DeserializeSha1(ReadOnlySpan<byte> span)
         {
-            var buf = new InputBuffer(buffer.ToArray()); // TODO: Perf
-            var reader = new SimpleBinaryReader<InputBuffer>(buf);
-
-            var wire = _sha1Deserializer.Deserialize<Sha1Wire>(reader);
-
-            var model = wire.Convert();
-            return model;
-        }
-
-        public override Sha1 DeserializeSha1(ArraySegment<byte> segment)
-        {
-            var buf = new InputBuffer(segment);
+            var buf = new InputBuffer(span.ToArray()); // TODO: Perf
             var reader = new SimpleBinaryReader<InputBuffer>(buf);
 
             var wire = _sha1Deserializer.Deserialize<Sha1Wire>(reader);

--- a/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Tree.cs
@@ -37,7 +37,7 @@ namespace SourceCode.Chasm.IO.Bond
 
         #region Deserialize
 
-        public override TreeNodeList DeserializeTree(ReadOnlyBuffer<byte> buffer)
+        public override TreeNodeList DeserializeTree(ReadOnlyMemory<byte> buffer)
         {
             var buf = new InputBuffer(buffer.ToArray()); // TODO: Perf
             var reader = new SimpleBinaryReader<InputBuffer>(buf);

--- a/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm.IO.Bond/BondChasmSerializer.Tree.cs
@@ -37,20 +37,9 @@ namespace SourceCode.Chasm.IO.Bond
 
         #region Deserialize
 
-        public override TreeNodeList DeserializeTree(ReadOnlyMemory<byte> buffer)
+        public override TreeNodeList DeserializeTree(ReadOnlySpan<byte> span)
         {
-            var buf = new InputBuffer(buffer.ToArray()); // TODO: Perf
-            var reader = new SimpleBinaryReader<InputBuffer>(buf);
-
-            var wire = _treeDeserializer.Deserialize<TreeWire>(reader);
-
-            var model = wire.Convert();
-            return model;
-        }
-
-        public override TreeNodeList DeserializeTree(ArraySegment<byte> segment)
-        {
-            var buf = new InputBuffer(segment);
+            var buf = new InputBuffer(span.ToArray()); // TODO: Perf
             var reader = new SimpleBinaryReader<InputBuffer>(buf);
 
             var wire = _treeDeserializer.Deserialize<TreeWire>(reader);

--- a/src/SourceCode.Chasm.IO.Bond/SourceCode.Chasm.IO.Bond.csproj
+++ b/src/SourceCode.Chasm.IO.Bond/SourceCode.Chasm.IO.Bond.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.0.3347">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Bond.Compiler.CSharp" Version="6.0.0" />

--- a/src/SourceCode.Chasm.IO.Json.Tests/CommitFixtures.cs
+++ b/src/SourceCode.Chasm.IO.Json.Tests/CommitFixtures.cs
@@ -6,8 +6,8 @@ namespace SourceCode.Chasm.IO.Json.Tests
     public static class CommitFixtures
     {
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(JsonCasSerializer_WriteRead_Commit))]
-        public static void JsonCasSerializer_WriteRead_Commit()
+        [Fact(DisplayName = nameof(JsonChasmSerializer_WriteRead_Commit))]
+        public static void JsonChasmSerializer_WriteRead_Commit()
         {
             var ser = new JsonChasmSerializer();
 

--- a/src/SourceCode.Chasm.IO.Json.Tests/NodeFixtures.cs
+++ b/src/SourceCode.Chasm.IO.Json.Tests/NodeFixtures.cs
@@ -7,8 +7,8 @@ namespace SourceCode.Chasm.IO.Json.Tests
         private static readonly ChasmSerializer _serializer = new JsonChasmSerializer();
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(JsonCasSerializer_WriteRead_NullTreeNodeList))]
-        public static void JsonCasSerializer_WriteRead_NullTreeNodeList()
+        [Fact(DisplayName = nameof(JsonChasmSerializer_WriteRead_NullTreeNodeList))]
+        public static void JsonChasmSerializer_WriteRead_NullTreeNodeList()
         {
             var expected = new TreeNodeList();
 
@@ -21,8 +21,8 @@ namespace SourceCode.Chasm.IO.Json.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(JsonCasSerializer_WriteRead_EmptyTreeNodeList))]
-        public static void JsonCasSerializer_WriteRead_EmptyTreeNodeList()
+        [Fact(DisplayName = nameof(JsonChasmSerializer_WriteRead_EmptyTreeNodeList))]
+        public static void JsonChasmSerializer_WriteRead_EmptyTreeNodeList()
         {
             var expected = new TreeNodeList(new TreeNode[0]);
 
@@ -35,8 +35,8 @@ namespace SourceCode.Chasm.IO.Json.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(JsonCasSerializer_WriteRead_TreeNodeList))]
-        public static void JsonCasSerializer_WriteRead_TreeNodeList()
+        [Fact(DisplayName = nameof(JsonChasmSerializer_WriteRead_TreeNodeList))]
+        public static void JsonChasmSerializer_WriteRead_TreeNodeList()
         {
             var expected = new TreeNodeList(new TreeNode("a", NodeKind.Blob, Sha1.Hash("abc")));
 

--- a/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Commit.cs
@@ -24,7 +24,7 @@ namespace SourceCode.Chasm.IO.Json
 
         #region Deserialize
 
-        public override Commit DeserializeCommit(ReadOnlyBuffer<byte> buffer)
+        public override Commit DeserializeCommit(ReadOnlyMemory<byte> buffer)
         {
             if (buffer.IsEmpty) throw new ArgumentNullException(nameof(buffer));
 

--- a/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Commit.cs
@@ -24,26 +24,18 @@ namespace SourceCode.Chasm.IO.Json
 
         #region Deserialize
 
-        public override Commit DeserializeCommit(ReadOnlyMemory<byte> buffer)
+        public override Commit DeserializeCommit(ReadOnlySpan<byte> span)
         {
-            if (buffer.IsEmpty) throw new ArgumentNullException(nameof(buffer));
+            if (span.IsEmpty) throw new ArgumentNullException(nameof(span));
 
             string json;
             unsafe
             {
-                fixed (byte* ptr = &buffer.Span.DangerousGetPinnableReference())
+                fixed (byte* ptr = &span.DangerousGetPinnableReference())
                 {
-                    json = Encoding.UTF8.GetString(ptr, buffer.Length);
+                    json = Encoding.UTF8.GetString(ptr, span.Length);
                 }
             }
-
-            var model = json.ParseCommit();
-            return model;
-        }
-
-        public override Commit DeserializeCommit(ArraySegment<byte> segment)
-        {
-            var json = Encoding.UTF8.GetString(segment.Array, segment.Offset, segment.Count);
 
             var model = json.ParseCommit();
             return model;

--- a/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Sha1.cs
@@ -21,26 +21,18 @@ namespace SourceCode.Chasm.IO.Json
 
         #region Deserialize
 
-        public override Sha1 DeserializeSha1(ReadOnlyMemory<byte> buffer)
+        public override Sha1 DeserializeSha1(ReadOnlySpan<byte> span)
         {
-            if (buffer.IsEmpty) throw new ArgumentNullException(nameof(buffer));
+            if (span.IsEmpty) throw new ArgumentNullException(nameof(span));
 
             string json;
             unsafe
             {
-                fixed (byte* ptr = &buffer.Span.DangerousGetPinnableReference())
+                fixed (byte* ptr = &span.DangerousGetPinnableReference())
                 {
-                    json = Encoding.UTF8.GetString(ptr, buffer.Length);
+                    json = Encoding.UTF8.GetString(ptr, span.Length);
                 }
             }
-
-            var model = Sha1.Parse(json);
-            return model;
-        }
-
-        public override Sha1 DeserializeSha1(ArraySegment<byte> segment)
-        {
-            var json = Encoding.UTF8.GetString(segment.Array, segment.Offset, segment.Count);
 
             var model = Sha1.Parse(json);
             return model;

--- a/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Sha1.cs
@@ -21,7 +21,7 @@ namespace SourceCode.Chasm.IO.Json
 
         #region Deserialize
 
-        public override Sha1 DeserializeSha1(ReadOnlyBuffer<byte> buffer)
+        public override Sha1 DeserializeSha1(ReadOnlyMemory<byte> buffer)
         {
             if (buffer.IsEmpty) throw new ArgumentNullException(nameof(buffer));
 

--- a/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Tree.cs
@@ -24,7 +24,7 @@ namespace SourceCode.Chasm.IO.Json
 
         #region Deserialize
 
-        public override TreeNodeList DeserializeTree(ReadOnlyBuffer<byte> buffer)
+        public override TreeNodeList DeserializeTree(ReadOnlyMemory<byte> buffer)
         {
             if (buffer.IsEmpty) throw new ArgumentNullException(nameof(buffer));
 

--- a/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Tree.cs
@@ -24,26 +24,18 @@ namespace SourceCode.Chasm.IO.Json
 
         #region Deserialize
 
-        public override TreeNodeList DeserializeTree(ReadOnlyMemory<byte> buffer)
+        public override TreeNodeList DeserializeTree(ReadOnlySpan<byte> span)
         {
-            if (buffer.IsEmpty) throw new ArgumentNullException(nameof(buffer));
+            if (span.IsEmpty) throw new ArgumentNullException(nameof(span));
 
             string json;
             unsafe
             {
-                fixed (byte* ptr = &buffer.Span.DangerousGetPinnableReference())
+                fixed (byte* ptr = &span.DangerousGetPinnableReference())
                 {
-                    json = Encoding.UTF8.GetString(ptr, buffer.Length);
+                    json = Encoding.UTF8.GetString(ptr, span.Length);
                 }
             }
-
-            var model = json.ParseTree();
-            return model;
-        }
-
-        public override TreeNodeList DeserializeTree(ArraySegment<byte> segment)
-        {
-            var json = Encoding.UTF8.GetString(segment.Array, segment.Offset, segment.Count);
 
             var model = json.ParseTree();
             return model;

--- a/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
+++ b/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.0.3347">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00131" />

--- a/src/SourceCode.Chasm.IO.Proto.Tests/CommitFixtures.cs
+++ b/src/SourceCode.Chasm.IO.Proto.Tests/CommitFixtures.cs
@@ -6,10 +6,10 @@ namespace SourceCode.Chasm.IO.Proto.Tests
     public static class CommitFixtures
     {
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(ProtoCasSerializer_WriteRead_Commit))]
-        public static void ProtoCasSerializer_WriteRead_Commit()
+        [Fact(DisplayName = nameof(ProtoChasmSerializer_WriteRead_Commit))]
+        public static void ProtoChasmSerializer_WriteRead_Commit()
         {
-            var ser = new ProtoCasSerializer();
+            var ser = new ProtoChasmSerializer();
 
             var parent = new CommitId(Sha1.Hash("abc"));
             var treeId = new TreeId(Sha1.Hash("def"));

--- a/src/SourceCode.Chasm.IO.Proto.Tests/NodeFixtures.cs
+++ b/src/SourceCode.Chasm.IO.Proto.Tests/NodeFixtures.cs
@@ -4,11 +4,11 @@ namespace SourceCode.Chasm.IO.Proto.Tests
 {
     public static class NodeFixtures
     {
-        private static readonly IChasmSerializer _serializer = new ProtoCasSerializer();
+        private static readonly IChasmSerializer _serializer = new ProtoChasmSerializer();
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(ProtoCasSerializer_WriteRead_NullTreeNodeList))]
-        public static void ProtoCasSerializer_WriteRead_NullTreeNodeList()
+        [Fact(DisplayName = nameof(ProtoChasmSerializer_WriteRead_NullTreeNodeList))]
+        public static void ProtoChasmSerializer_WriteRead_NullTreeNodeList()
         {
             var expected = new TreeNodeList();
 
@@ -21,8 +21,8 @@ namespace SourceCode.Chasm.IO.Proto.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(ProtoCasSerializer_WriteRead_EmptyTreeNodeList))]
-        public static void ProtoCasSerializer_WriteRead_EmptyTreeNodeList()
+        [Fact(DisplayName = nameof(ProtoChasmSerializer_WriteRead_EmptyTreeNodeList))]
+        public static void ProtoChasmSerializer_WriteRead_EmptyTreeNodeList()
         {
             var expected = new TreeNodeList(new TreeNode[0]);
 
@@ -35,8 +35,8 @@ namespace SourceCode.Chasm.IO.Proto.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(ProtoCasSerializer_WriteRead_TreeNodeList))]
-        public static void ProtoCasSerializer_WriteRead_TreeNodeList()
+        [Fact(DisplayName = nameof(ProtoChasmSerializer_WriteRead_TreeNodeList))]
+        public static void ProtoChasmSerializer_WriteRead_TreeNodeList()
         {
             var nodes = new[]
             {

--- a/src/SourceCode.Chasm.IO.Proto/ProtoCasSerializer.Commit.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoCasSerializer.Commit.cs
@@ -31,7 +31,7 @@ namespace SourceCode.Chasm.IO.Proto
 
         #region Deserialize
 
-        public override Commit DeserializeCommit(ReadOnlyBuffer<byte> buffer)
+        public override Commit DeserializeCommit(ReadOnlyMemory<byte> buffer)
         {
             var wire = new CommitWire();
             wire.MergeFrom(buffer.ToArray()); // TODO: Perf

--- a/src/SourceCode.Chasm.IO.Proto/ProtoCasSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoCasSerializer.Sha1.cs
@@ -31,7 +31,7 @@ namespace SourceCode.Chasm.IO.Proto
 
         #region Deserialize
 
-        public unsafe override Sha1 DeserializeSha1(ReadOnlyBuffer<byte> buffer)
+        public unsafe override Sha1 DeserializeSha1(ReadOnlyMemory<byte> buffer)
         {
             var wire = new Sha1Wire();
             wire.MergeFrom(buffer.ToArray()); // TODO: Perf

--- a/src/SourceCode.Chasm.IO.Proto/ProtoCasSerializer.Tree.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoCasSerializer.Tree.cs
@@ -31,7 +31,7 @@ namespace SourceCode.Chasm.IO.Proto
 
         #region Deserialize
 
-        public override TreeNodeList DeserializeTree(ReadOnlyBuffer<byte> buffer)
+        public override TreeNodeList DeserializeTree(ReadOnlyMemory<byte> buffer)
         {
             var wire = new TreeWire();
             wire.MergeFrom(buffer.ToArray()); // TODO: Perf

--- a/src/SourceCode.Chasm.IO.Proto/ProtoCasSerializer.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoCasSerializer.cs
@@ -1,6 +1,0 @@
-﻿namespace SourceCode.Chasm.IO.Proto
-{
-    public sealed partial class ProtoCasSerializer : ChasmSerializer
-    {
-    }
-}

--- a/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Commit.cs
@@ -31,19 +31,10 @@ namespace SourceCode.Chasm.IO.Proto
 
         #region Deserialize
 
-        public override Commit DeserializeCommit(ReadOnlyMemory<byte> buffer)
+        public override Commit DeserializeCommit(ReadOnlySpan<byte> span)
         {
             var wire = new CommitWire();
-            wire.MergeFrom(buffer.ToArray()); // TODO: Perf
-
-            var model = wire.Convert();
-            return model;
-        }
-
-        public override Commit DeserializeCommit(ArraySegment<byte> segment)
-        {
-            var wire = new CommitWire();
-            wire.MergeFrom(segment.ToArray()); // TODO: Perf
+            wire.MergeFrom(span.ToArray()); // TODO: Perf
 
             var model = wire.Convert();
             return model;

--- a/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Commit.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace SourceCode.Chasm.IO.Proto
 {
-    partial class ProtoCasSerializer // .Commit
+    partial class ProtoChasmSerializer // .Commit
     {
         #region Serialize
 

--- a/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Sha1.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace SourceCode.Chasm.IO.Proto
 {
-    partial class ProtoCasSerializer // .Sha1
+    partial class ProtoChasmSerializer // .Sha1
     {
         #region Serialize
 

--- a/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Sha1.cs
@@ -31,19 +31,10 @@ namespace SourceCode.Chasm.IO.Proto
 
         #region Deserialize
 
-        public unsafe override Sha1 DeserializeSha1(ReadOnlyMemory<byte> buffer)
+        public unsafe override Sha1 DeserializeSha1(ReadOnlySpan<byte> span)
         {
             var wire = new Sha1Wire();
-            wire.MergeFrom(buffer.ToArray()); // TODO: Perf
-
-            var model = wire.Convert();
-            return model;
-        }
-
-        public unsafe override Sha1 DeserializeSha1(ArraySegment<byte> segment)
-        {
-            var wire = new Sha1Wire();
-            wire.MergeFrom(segment.ToArray()); // TODO: Perf
+            wire.MergeFrom(span.ToArray()); // TODO: Perf
 
             var model = wire.Convert();
             return model;

--- a/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Tree.cs
@@ -31,19 +31,10 @@ namespace SourceCode.Chasm.IO.Proto
 
         #region Deserialize
 
-        public override TreeNodeList DeserializeTree(ReadOnlyMemory<byte> buffer)
+        public override TreeNodeList DeserializeTree(ReadOnlySpan<byte> span)
         {
             var wire = new TreeWire();
-            wire.MergeFrom(buffer.ToArray()); // TODO: Perf
-
-            var model = wire.Convert();
-            return model;
-        }
-
-        public override TreeNodeList DeserializeTree(ArraySegment<byte> segment)
-        {
-            var wire = new TreeWire();
-            wire.MergeFrom(segment.ToArray()); // TODO: Perf
+            wire.MergeFrom(span.ToArray()); // TODO: Perf
 
             var model = wire.Convert();
             return model;

--- a/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Tree.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace SourceCode.Chasm.IO.Proto
 {
-    partial class ProtoCasSerializer // .Tree
+    partial class ProtoChasmSerializer // .Tree
     {
         #region Serialize
 

--- a/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.cs
@@ -1,0 +1,6 @@
+﻿namespace SourceCode.Chasm.IO.Proto
+{
+    public sealed partial class ProtoChasmSerializer : ChasmSerializer
+    {
+    }
+}

--- a/src/SourceCode.Chasm.IO.Proto/SourceCode.Chasm.IO.Proto.csproj
+++ b/src/SourceCode.Chasm.IO.Proto/SourceCode.Chasm.IO.Proto.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.0.3347">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Google.Protobuf" Version="3.4.1" />

--- a/src/SourceCode.Chasm.Tests/Sha1Tests.cs
+++ b/src/SourceCode.Chasm.Tests/Sha1Tests.cs
@@ -54,25 +54,183 @@ namespace SourceCode.Chasm.Tests
             actual = Sha1.Parse("0x" + expected.ToString("S"));
             Assert.Equal(expected, actual);
             Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+        }
 
-            // Get Byte[]
-            var buffer = new byte[Sha1.ByteLen];
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_Bytes))]
+        public static void When_construct_sha1_from_Bytes()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLen + 10];
+
+            // Construct Byte[]
             expected.CopyTo(buffer, 0);
-
-            // Roundtrip Byte[]
-            actual = new Sha1(buffer);
+            var actual = new Sha1(buffer);
             Assert.Equal(expected, actual);
             Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
 
-            // Roundtrip Segment
-            actual = new Sha1(new ArraySegment<byte>(buffer));
+            // Construct Byte[] with offset 0
+            expected.CopyTo(buffer, 0);
+            actual = new Sha1(buffer, 0);
             Assert.Equal(expected, actual);
             Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
 
-            // Roundtrip Buffer
-            //actual = new Sha1(new ReadOnlyBuffer<byte>(buffer));
-            //Assert.Equal(expected, actual);
-            //Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Construct Byte[] with offset N
+            expected.CopyTo(buffer, 5);
+            actual = new Sha1(buffer, 5);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_ArraySegment))]
+        public static void When_construct_sha1_from_ArraySegment()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLen + 10];
+
+            // Construct Byte[] with offset N
+            expected.CopyTo(buffer, 5);
+            var actual = new Sha1(buffer, 5);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct Segment
+            expected.CopyTo(buffer, 0);
+            var seg = new ArraySegment<byte>(buffer);
+            actual = new Sha1(seg);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct Segment with offset 0
+            expected.CopyTo(buffer, 0);
+            seg = new ArraySegment<byte>(buffer, 0, Sha1.ByteLen);
+            actual = new Sha1(seg);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct Segment with offset N
+            expected.CopyTo(buffer, 5);
+            seg = new ArraySegment<byte>(buffer, 5, Sha1.ByteLen);
+            actual = new Sha1(seg);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_Memory))]
+        public static void When_construct_sha1_from_Memory()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLen + 10];
+
+            // Construct Memory
+            expected.CopyTo(buffer, 0);
+            var mem = new Memory<byte>(buffer);
+            var actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct Memory with offset 0
+            expected.CopyTo(buffer, 0);
+            mem = new Memory<byte>(buffer, 0, Sha1.ByteLen);
+            actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct Memory with offset N
+            expected.CopyTo(buffer, 5);
+            mem = new Memory<byte>(buffer, 5, Sha1.ByteLen);
+            actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_ReadOnlyMemory))]
+        public static void When_construct_sha1_from_ReadOnlyMemory()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLen + 10];
+
+            // Construct ReadOnlyMemory
+            expected.CopyTo(buffer, 0);
+            var mem = new ReadOnlyMemory<byte>(buffer);
+            var actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct ReadOnlyMemory with offset 0
+            expected.CopyTo(buffer, 0);
+            mem = new ReadOnlyMemory<byte>(buffer, 0, Sha1.ByteLen);
+            actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct ReadOnlyMemory with offset N
+            expected.CopyTo(buffer, 5);
+            mem = new ReadOnlyMemory<byte>(buffer, 5, Sha1.ByteLen);
+            actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_Span))]
+        public static void When_construct_sha1_from_Span()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLen + 10];
+
+            // Construct Span
+            expected.CopyTo(buffer, 0);
+            var span = new Span<byte>(buffer);
+            var actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct Span with offset 0
+            expected.CopyTo(buffer, 0);
+            span = new Span<byte>(buffer, 0, Sha1.ByteLen);
+            actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct Span with offset N
+            expected.CopyTo(buffer, 5);
+            span = new Span<byte>(buffer, 5, Sha1.ByteLen);
+            actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_ReadOnlySpan))]
+        public static void When_construct_sha1_from_ReadOnlySpan()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLen + 10];
+
+            // Construct ReadOnlySpan
+            expected.CopyTo(buffer, 0);
+            var span = new ReadOnlySpan<byte>(buffer);
+            var actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct ReadOnlySpan with offset 0
+            expected.CopyTo(buffer, 0);
+            span = new ReadOnlySpan<byte>(buffer, 0, Sha1.ByteLen);
+            actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+            // Construct ReadOnlySpan with offset N
+            expected.CopyTo(buffer, 5);
+            span = new ReadOnlySpan<byte>(buffer, 5, Sha1.ByteLen);
+            actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
         }
 
         [Trait("Type", "Unit")]
@@ -149,7 +307,7 @@ namespace SourceCode.Chasm.Tests
                 Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
 
                 // Roundtrip Buffer
-                //actual = new Sha1(new ReadOnlyBuffer<byte>(buffer)).ToString();
+                //actual = new Sha1(new ReadOnlyMemory<byte>(buffer)).ToString();
                 //Assert.Equal(expected, actual);
                 //Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
             }
@@ -218,7 +376,7 @@ namespace SourceCode.Chasm.Tests
                 Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
 
                 // Roundtrip Buffer
-                //actual = new Sha1(new ReadOnlyBuffer<byte>(buffer)).ToString();
+                //actual = new Sha1(new ReadOnlyMemory<byte>(buffer)).ToString();
                 //Assert.Equal(expected, actual);
                 //Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
             }
@@ -287,7 +445,7 @@ namespace SourceCode.Chasm.Tests
                 Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
 
                 // Roundtrip Buffer
-                //    actual = new Sha1(new ReadOnlyBuffer<byte>(buffer)).ToString();
+                //    actual = new Sha1(new ReadOnlyMemory<byte>(buffer)).ToString();
                 //    Assert.Equal(expected, actual);
                 //    Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
             }
@@ -355,7 +513,7 @@ namespace SourceCode.Chasm.Tests
                 Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
 
                 // Roundtrip Buffer
-                //actual = new Sha1(new ReadOnlyBuffer<byte>(buffer)).ToString();
+                //actual = new Sha1(new ReadOnlyMemory<byte>(buffer)).ToString();
                 //Assert.Equal(expected, actual);
                 //Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
             }
@@ -424,7 +582,7 @@ namespace SourceCode.Chasm.Tests
                 Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
 
                 // Roundtrip Buffer
-                //actual = new Sha1(new ReadOnlyBuffer<byte>(buffer)).ToString();
+                //actual = new Sha1(new ReadOnlyMemory<byte>(buffer)).ToString();
                 //Assert.Equal(expected, actual);
                 //Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
             }

--- a/src/SourceCode.Chasm/Blob.cs
+++ b/src/SourceCode.Chasm/Blob.cs
@@ -34,7 +34,7 @@ namespace SourceCode.Chasm
         #region IEquatable
 
         public bool Equals(Blob other)
-            => BufferComparer.Default.Equals(Data, other.Data); // Callee has null-handling logic
+            => BufferComparer.Default.Equals(Data, other.Data); // Callee has necessary null-handling logic
 
         public override bool Equals(object obj)
             => obj is Blob blob

--- a/src/SourceCode.Chasm/IO/ChasmRepository.Commit.cs
+++ b/src/SourceCode.Chasm/IO/ChasmRepository.Commit.cs
@@ -13,7 +13,7 @@ namespace SourceCode.Chasm.IO
             if (buffer.IsEmpty)
                 return Commit.Empty;
 
-            var model = Serializer.DeserializeCommit(buffer);
+            var model = Serializer.DeserializeCommit(buffer.Span);
             return model;
         }
 
@@ -23,7 +23,7 @@ namespace SourceCode.Chasm.IO
             if (buffer.IsEmpty)
                 return Commit.Empty;
 
-            var model = Serializer.DeserializeCommit(buffer);
+            var model = Serializer.DeserializeCommit(buffer.Span);
             return model;
         }
 

--- a/src/SourceCode.Chasm/IO/ChasmRepository.Object.cs
+++ b/src/SourceCode.Chasm/IO/ChasmRepository.Object.cs
@@ -17,22 +17,22 @@ namespace SourceCode.Chasm.IO
 
         #region Read
 
-        public abstract ReadOnlyBuffer<byte> ReadObject(Sha1 objectId);
+        public abstract ReadOnlyMemory<byte> ReadObject(Sha1 objectId);
 
-        public abstract ValueTask<ReadOnlyBuffer<byte>> ReadObjectAsync(Sha1 objectId, CancellationToken cancellationToken);
+        public abstract ValueTask<ReadOnlyMemory<byte>> ReadObjectAsync(Sha1 objectId, CancellationToken cancellationToken);
 
-        public virtual IReadOnlyDictionary<Sha1, ReadOnlyBuffer<byte>> ReadObjects(IEnumerable<Sha1> objectIds, CancellationToken cancellationToken)
+        public virtual IReadOnlyDictionary<Sha1, ReadOnlyMemory<byte>> ReadObjects(IEnumerable<Sha1> objectIds, CancellationToken cancellationToken)
         {
-            if (objectIds == null) return ReadOnlyDictionary.Empty<Sha1, ReadOnlyBuffer<byte>>();
+            if (objectIds == null) return ReadOnlyDictionary.Empty<Sha1, ReadOnlyMemory<byte>>();
 
             if (objectIds is ICollection<Sha1> sha1s)
             {
-                if (sha1s.Count == 0) return ReadOnlyDictionary.Empty<Sha1, ReadOnlyBuffer<byte>>();
+                if (sha1s.Count == 0) return ReadOnlyDictionary.Empty<Sha1, ReadOnlyMemory<byte>>();
 
                 // For small count, run non-concurrent
                 if (sha1s.Count <= ConcurrentThreshold)
                 {
-                    var dict = new Dictionary<Sha1, ReadOnlyBuffer<byte>>(sha1s.Count);
+                    var dict = new Dictionary<Sha1, ReadOnlyMemory<byte>>(sha1s.Count);
 
                     foreach (var sha1 in sha1s)
                     {
@@ -49,18 +49,18 @@ namespace SourceCode.Chasm.IO
             return result;
         }
 
-        public virtual async ValueTask<IReadOnlyDictionary<Sha1, ReadOnlyBuffer<byte>>> ReadObjectsAsync(IEnumerable<Sha1> objectIds, CancellationToken cancellationToken)
+        public virtual async ValueTask<IReadOnlyDictionary<Sha1, ReadOnlyMemory<byte>>> ReadObjectsAsync(IEnumerable<Sha1> objectIds, CancellationToken cancellationToken)
         {
-            if (objectIds == null) return ReadOnlyDictionary.Empty<Sha1, ReadOnlyBuffer<byte>>();
+            if (objectIds == null) return ReadOnlyDictionary.Empty<Sha1, ReadOnlyMemory<byte>>();
 
             if (objectIds is ICollection<Sha1> sha1s)
             {
-                if (sha1s.Count == 0) return ReadOnlyDictionary.Empty<Sha1, ReadOnlyBuffer<byte>>();
+                if (sha1s.Count == 0) return ReadOnlyDictionary.Empty<Sha1, ReadOnlyMemory<byte>>();
 
                 // For small count, run non-concurrent
                 if (sha1s.Count <= ConcurrentThreshold)
                 {
-                    var dict = new Dictionary<Sha1, ReadOnlyBuffer<byte>>(sha1s.Count);
+                    var dict = new Dictionary<Sha1, ReadOnlyMemory<byte>>(sha1s.Count);
 
                     foreach (var sha1 in sha1s)
                     {
@@ -78,7 +78,7 @@ namespace SourceCode.Chasm.IO
             return result;
         }
 
-        private IReadOnlyDictionary<Sha1, ReadOnlyBuffer<byte>> ReadConcurrent(IEnumerable<Sha1> objectIds, CancellationToken cancellationToken)
+        private IReadOnlyDictionary<Sha1, ReadOnlyMemory<byte>> ReadConcurrent(IEnumerable<Sha1> objectIds, CancellationToken cancellationToken)
         {
             var options = new ParallelOptions
             {
@@ -86,7 +86,7 @@ namespace SourceCode.Chasm.IO
                 MaxDegreeOfParallelism = MaxDop
             };
 
-            var dict = new ConcurrentDictionary<Sha1, ReadOnlyBuffer<byte>>();
+            var dict = new ConcurrentDictionary<Sha1, ReadOnlyMemory<byte>>();
 
             Parallel.ForEach(objectIds, options, sha1 =>
             {

--- a/src/SourceCode.Chasm/IO/ChasmRepository.Tree.cs
+++ b/src/SourceCode.Chasm/IO/ChasmRepository.Tree.cs
@@ -20,7 +20,7 @@ namespace SourceCode.Chasm.IO
                 return TreeNodeList.Empty;
 
             // Deserialize
-            var tree = Serializer.DeserializeTree(buffer);
+            var tree = Serializer.DeserializeTree(buffer.Span);
             return tree;
         }
 
@@ -34,7 +34,7 @@ namespace SourceCode.Chasm.IO
                 return TreeNodeList.Empty;
 
             // Deserialize
-            var tree = Serializer.DeserializeTree(buffer);
+            var tree = Serializer.DeserializeTree(buffer.Span);
             return tree;
         }
 
@@ -70,7 +70,7 @@ namespace SourceCode.Chasm.IO
 
             foreach (var kvp in kvps)
             {
-                var tree = Serializer.DeserializeTree(kvp.Value);
+                var tree = Serializer.DeserializeTree(kvp.Value.Span);
 
                 var treeId = new TreeId(kvp.Key);
                 dict[treeId] = tree;

--- a/src/SourceCode.Chasm/IO/ChasmRepository.Tree.cs
+++ b/src/SourceCode.Chasm/IO/ChasmRepository.Tree.cs
@@ -64,7 +64,7 @@ namespace SourceCode.Chasm.IO
             return dict;
         }
 
-        private IReadOnlyDictionary<TreeId, TreeNodeList> DeserializeTrees(IReadOnlyDictionary<Sha1, System.ReadOnlyBuffer<byte>> kvps)
+        private IReadOnlyDictionary<TreeId, TreeNodeList> DeserializeTrees(IReadOnlyDictionary<Sha1, System.ReadOnlyMemory<byte>> kvps)
         {
             var dict = new Dictionary<TreeId, TreeNodeList>(kvps.Count);
 

--- a/src/SourceCode.Chasm/IO/ChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm/IO/ChasmSerializer.Commit.cs
@@ -7,8 +7,6 @@ namespace SourceCode.Chasm.IO
     {
         public abstract BufferSession Serialize(Commit model);
 
-        public abstract Commit DeserializeCommit(ReadOnlyMemory<byte> buffer);
-
-        public abstract Commit DeserializeCommit(ArraySegment<byte> segment);
+        public abstract Commit DeserializeCommit(ReadOnlySpan<byte> span);
     }
 }

--- a/src/SourceCode.Chasm/IO/ChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm/IO/ChasmSerializer.Commit.cs
@@ -7,7 +7,7 @@ namespace SourceCode.Chasm.IO
     {
         public abstract BufferSession Serialize(Commit model);
 
-        public abstract Commit DeserializeCommit(ReadOnlyBuffer<byte> buffer);
+        public abstract Commit DeserializeCommit(ReadOnlyMemory<byte> buffer);
 
         public abstract Commit DeserializeCommit(ArraySegment<byte> segment);
     }

--- a/src/SourceCode.Chasm/IO/ChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm/IO/ChasmSerializer.Sha1.cs
@@ -7,7 +7,7 @@ namespace SourceCode.Chasm.IO
     {
         public abstract BufferSession Serialize(Sha1 model);
 
-        public abstract Sha1 DeserializeSha1(ReadOnlyBuffer<byte> buffer);
+        public abstract Sha1 DeserializeSha1(ReadOnlyMemory<byte> buffer);
 
         public abstract Sha1 DeserializeSha1(ArraySegment<byte> segment);
     }

--- a/src/SourceCode.Chasm/IO/ChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm/IO/ChasmSerializer.Sha1.cs
@@ -7,8 +7,6 @@ namespace SourceCode.Chasm.IO
     {
         public abstract BufferSession Serialize(Sha1 model);
 
-        public abstract Sha1 DeserializeSha1(ReadOnlyMemory<byte> buffer);
-
-        public abstract Sha1 DeserializeSha1(ArraySegment<byte> segment);
+        public abstract Sha1 DeserializeSha1(ReadOnlySpan<byte> span);
     }
 }

--- a/src/SourceCode.Chasm/IO/ChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm/IO/ChasmSerializer.Tree.cs
@@ -7,7 +7,7 @@ namespace SourceCode.Chasm.IO
     {
         public abstract BufferSession Serialize(TreeNodeList model);
 
-        public abstract TreeNodeList DeserializeTree(ReadOnlyBuffer<byte> buffer);
+        public abstract TreeNodeList DeserializeTree(ReadOnlyMemory<byte> buffer);
 
         public abstract TreeNodeList DeserializeTree(ArraySegment<byte> segment);
     }

--- a/src/SourceCode.Chasm/IO/ChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm/IO/ChasmSerializer.Tree.cs
@@ -7,8 +7,6 @@ namespace SourceCode.Chasm.IO
     {
         public abstract BufferSession Serialize(TreeNodeList model);
 
-        public abstract TreeNodeList DeserializeTree(ReadOnlyMemory<byte> buffer);
-
-        public abstract TreeNodeList DeserializeTree(ArraySegment<byte> segment);
+        public abstract TreeNodeList DeserializeTree(ReadOnlySpan<byte> span);
     }
 }

--- a/src/SourceCode.Chasm/IO/IChasmRepository.Object.cs
+++ b/src/SourceCode.Chasm/IO/IChasmRepository.Object.cs
@@ -9,13 +9,13 @@ namespace SourceCode.Chasm.IO
     {
         #region Read
 
-        ReadOnlyBuffer<byte> ReadObject(Sha1 objectId);
+        ReadOnlyMemory<byte> ReadObject(Sha1 objectId);
 
-        ValueTask<ReadOnlyBuffer<byte>> ReadObjectAsync(Sha1 objectId, CancellationToken cancellationToken);
+        ValueTask<ReadOnlyMemory<byte>> ReadObjectAsync(Sha1 objectId, CancellationToken cancellationToken);
 
-        IReadOnlyDictionary<Sha1, ReadOnlyBuffer<byte>> ReadObjects(IEnumerable<Sha1> objectIds, CancellationToken cancellationToken);
+        IReadOnlyDictionary<Sha1, ReadOnlyMemory<byte>> ReadObjects(IEnumerable<Sha1> objectIds, CancellationToken cancellationToken);
 
-        ValueTask<IReadOnlyDictionary<Sha1, ReadOnlyBuffer<byte>>> ReadObjectsAsync(IEnumerable<Sha1> objectIds, CancellationToken cancellationToken);
+        ValueTask<IReadOnlyDictionary<Sha1, ReadOnlyMemory<byte>>> ReadObjectsAsync(IEnumerable<Sha1> objectIds, CancellationToken cancellationToken);
 
         #endregion
 

--- a/src/SourceCode.Chasm/IO/IChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm/IO/IChasmSerializer.Commit.cs
@@ -7,8 +7,6 @@ namespace SourceCode.Chasm.IO
     {
         BufferSession Serialize(Commit model);
 
-        Commit DeserializeCommit(ReadOnlyMemory<byte> buffer);
-
-        Commit DeserializeCommit(ArraySegment<byte> segment);
+        Commit DeserializeCommit(ReadOnlySpan<byte> span);
     }
 }

--- a/src/SourceCode.Chasm/IO/IChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm/IO/IChasmSerializer.Commit.cs
@@ -7,7 +7,7 @@ namespace SourceCode.Chasm.IO
     {
         BufferSession Serialize(Commit model);
 
-        Commit DeserializeCommit(ReadOnlyBuffer<byte> buffer);
+        Commit DeserializeCommit(ReadOnlyMemory<byte> buffer);
 
         Commit DeserializeCommit(ArraySegment<byte> segment);
     }

--- a/src/SourceCode.Chasm/IO/IChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm/IO/IChasmSerializer.Sha1.cs
@@ -7,7 +7,7 @@ namespace SourceCode.Chasm.IO
     {
         BufferSession Serialize(Sha1 model);
 
-        Sha1 DeserializeSha1(ReadOnlyBuffer<byte> buffer);
+        Sha1 DeserializeSha1(ReadOnlyMemory<byte> buffer);
 
         Sha1 DeserializeSha1(ArraySegment<byte> segment);
     }

--- a/src/SourceCode.Chasm/IO/IChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm/IO/IChasmSerializer.Sha1.cs
@@ -7,8 +7,6 @@ namespace SourceCode.Chasm.IO
     {
         BufferSession Serialize(Sha1 model);
 
-        Sha1 DeserializeSha1(ReadOnlyMemory<byte> buffer);
-
-        Sha1 DeserializeSha1(ArraySegment<byte> segment);
+        Sha1 DeserializeSha1(ReadOnlySpan<byte> span);
     }
 }

--- a/src/SourceCode.Chasm/IO/IChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm/IO/IChasmSerializer.Tree.cs
@@ -7,7 +7,7 @@ namespace SourceCode.Chasm.IO
     {
         BufferSession Serialize(TreeNodeList model);
 
-        TreeNodeList DeserializeTree(ReadOnlyBuffer<byte> buffer);
+        TreeNodeList DeserializeTree(ReadOnlyMemory<byte> buffer);
 
         TreeNodeList DeserializeTree(ArraySegment<byte> segment);
     }

--- a/src/SourceCode.Chasm/IO/IChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm/IO/IChasmSerializer.Tree.cs
@@ -7,8 +7,6 @@ namespace SourceCode.Chasm.IO
     {
         BufferSession Serialize(TreeNodeList model);
 
-        TreeNodeList DeserializeTree(ReadOnlyMemory<byte> buffer);
-
-        TreeNodeList DeserializeTree(ArraySegment<byte> segment);
+        TreeNodeList DeserializeTree(ReadOnlySpan<byte> span);
     }
 }

--- a/src/SourceCode.Chasm/Sha1.cs
+++ b/src/SourceCode.Chasm/Sha1.cs
@@ -84,33 +84,6 @@ namespace SourceCode.Chasm
         }
 
         /// <summary>
-        /// Deserializes a <see cref="Sha1"/> value from the provided <see cref="Byte[]"/>.
-        /// </summary>
-        /// <param name="buffer">The buffer.</param>
-        /// <exception cref="ArgumentNullException">buffer</exception>
-        /// <exception cref="ArgumentOutOfRangeException">buffer - buffer</exception>
-        [SecuritySafeCritical]
-        public Sha1(byte[] buffer)
-        {
-            if (buffer == null)
-                throw new ArgumentNullException(nameof(buffer));
-
-            if (buffer.Length < ByteLen)
-                throw new ArgumentOutOfRangeException(nameof(buffer), $"{nameof(buffer)} must have length at least {ByteLen}");
-
-            unsafe
-            {
-                fixed (byte* ptr = buffer)
-                {
-                    // Code is valid per BitConverter.ToInt32|64 (see #1 elsewhere in this class)
-                    Blit0 = *(ulong*)(&ptr[0]);
-                    Blit1 = *(ulong*)(&ptr[8]);
-                    Blit2 = *(uint*)(&ptr[16]);
-                }
-            }
-        }
-
-        /// <summary>
         /// Deserializes a <see cref="Sha1"/> value from the provided <see cref="Byte[]"/> starting at the specified position.
         /// </summary>
         /// <param name="buffer">The buffer.</param>
@@ -145,66 +118,25 @@ namespace SourceCode.Chasm
             }
         }
 
-        // Commenting out this section until System.Buffers.Primitives is RTM
-#pragma warning disable S125 // Sections of code should not be "commented out"
-
         /// <summary>
-        /// Deserializes a <see cref="Sha1"/> value from the provided <see cref="ReadOnlyBuffer{T}"/>.
+        /// Deserializes a <see cref="Sha1"/> value from the provided <see cref="ReadOnlyMemory{T}"/>.
         /// </summary>
-        /// <param name="buffer">The buffer.</param>
-        /// <exception cref="ArgumentOutOfRangeException">buffer - buffer</exception>
-        //[SecuritySafeCritical]
-        //public Sha1(ReadOnlyBuffer<byte> buffer)
-        //{
-        //    if (buffer.Length < ByteLen)
-        //        throw new ArgumentOutOfRangeException(nameof(buffer), $"{nameof(buffer)} must have length at least {ByteLen}");
-
-        //    unsafe
-        //    {
-        //        fixed (byte* ptr = &buffer.Span.DangerousGetPinnableReference())
-        //        {
-        //            // Code is valid per BitConverter.ToInt32|64 (see #1 elsewhere in this class)
-        //            Blit0 = *(ulong*)(&ptr[0]);
-        //            Blit1 = *(ulong*)(&ptr[8]);
-        //            Blit2 = *(uint*)(&ptr[16]);
-        //        }
-        //    }
-        //}
-
-        /// <summary>
-        /// Deserializes a <see cref="Sha1"/> value from the provided <see cref="ReadOnlyBuffer{T}"/> starting at the specified position.
-        /// </summary>
-        /// <param name="buffer">The buffer.</param>
-        /// <param name="offset">The offset.</param>
-        /// <exception cref="ArgumentOutOfRangeException">offset - buffer</exception>
-        //public Sha1(ReadOnlyBuffer<byte> buffer, int offset)
-        //    : this(buffer.Slice(offset, ByteLen))
-        //{
-        //    if (offset < 0 || offset + ByteLen > buffer.Length)
-        //        throw new ArgumentOutOfRangeException(nameof(offset), $"{nameof(buffer)} must have length at least {ByteLen}");
-        //}
-
-#pragma warning restore S125 // Sections of code should not be "commented out"
-
-        /// <summary>
-        /// Deserializes a <see cref="Sha1"/> value from the provided <see cref="ArraySegment{T}"/>.
-        /// </summary>
-        /// <param name="buffer">The buffer.</param>
+        /// <param name="span">The buffer.</param>
         /// <exception cref="ArgumentOutOfRangeException">buffer - buffer</exception>
         [SecuritySafeCritical]
-        public Sha1(ArraySegment<byte> buffer)
+        public Sha1(ReadOnlySpan<byte> span)
         {
-            if (buffer.Count < ByteLen)
-                throw new ArgumentOutOfRangeException(nameof(buffer), $"{nameof(buffer)} must have length at least {ByteLen}");
+            if (span.IsEmpty || span.Length < ByteLen)
+                throw new ArgumentOutOfRangeException(nameof(span), $"{nameof(span)} must have length at least {ByteLen}");
 
             unsafe
             {
-                fixed (byte* ptr = buffer.Array)
+                fixed (byte* ptr = &span.DangerousGetPinnableReference())
                 {
                     // Code is valid per BitConverter.ToInt32|64 (see #1 elsewhere in this class)
-                    Blit0 = *(ulong*)(&ptr[buffer.Offset + 0]);
-                    Blit1 = *(ulong*)(&ptr[buffer.Offset + 8]);
-                    Blit2 = *(uint*)(&ptr[buffer.Offset + 16]);
+                    Blit0 = *(ulong*)(&ptr[0]);
+                    Blit1 = *(ulong*)(&ptr[8]);
+                    Blit2 = *(uint*)(&ptr[16]);
                 }
             }
         }
@@ -337,37 +269,6 @@ namespace SourceCode.Chasm
             return ByteLen;
         }
 
-        // Commenting out this section until System.Buffers.Primitives is RTM
-#pragma warning disable S125 // Sections of code should not be "commented out"
-
-        /// <summary>
-        /// Copies the <see cref="Sha1"/> value to the provided buffer.
-        /// </summary>
-        /// <param name="buffer">The buffer to copy to.</param>
-        /// <param name="offset">The offset.</param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException">offset - buffer</exception>
-        //[SecuritySafeCritical]
-        //public int CopyTo(Buffer<byte> buffer, int offset)
-        //{
-        //    if (offset < 0 || offset + ByteLen > buffer.Length)
-        //        throw new ArgumentOutOfRangeException(nameof(offset), $"{nameof(buffer)} must have length at least {ByteLen}");
-
-        //    unsafe
-        //    {
-        //        fixed (byte* ptr = &buffer.Span.DangerousGetPinnableReference())
-        //        {
-        //            // Code is valid per BitConverter.ToInt32|64 (see #1 elsewhere in this class)
-        //            *(ulong*)(&ptr[offset + 0]) = Blit0;
-        //            *(ulong*)(&ptr[offset + 8]) = Blit1;
-        //            *(uint*)(&ptr[offset + 16]) = Blit2;
-        //        }
-        //    }
-
-        //    return ByteLen;
-        //}
-#pragma warning restore S125 // Sections of code should not be "commented out"
-
         #endregion
 
         #region ToString
@@ -447,7 +348,8 @@ namespace SourceCode.Chasm
             var key = new string(chars, 0, prefixLength);
             var val = new string(chars, prefixLength, chars.Length - prefixLength);
 
-            return new KeyValuePair<string, string>(key, val);
+            var kvp = new KeyValuePair<string, string>(key, val);
+            return kvp;
         }
 
         [SecuritySafeCritical]

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -26,11 +26,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.0.3347">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00131" />
     <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00131" />
-    <PackageReference Include="System.Buffers.Primitives" Version="0.1.0-e170811-6" />
+    <PackageReference Include="System.Memory" Version="4.5.0-preview2-25707-02" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- System.Buffers.Primitives is in official preview, renamed to System.Memory
- Align changes
- Update I/O design of Sha1 based on new libs
- Fix naming issues of (eg) CasRepo -> ChasmRepo
- Add missing units