### PR TITLE
Fix UTF8 estimation

### DIFF
--- a/src/SourceCode.Chasm.IO.Bond/Wire/CommitWireExtensions.cs
+++ b/src/SourceCode.Chasm.IO.Bond/Wire/CommitWireExtensions.cs
@@ -21,7 +21,7 @@ namespace SourceCode.Chasm.IO.Bond.Wire
             len += sizeof(long);
 
             // CommitMessage
-            len += 2 * (wire.CommitMessage?.Length ?? 0); // utf8
+            len += (wire.CommitMessage?.Length ?? 0) * 3; // Utf8 is 1-3 bpc
 
             return len;
         }

--- a/src/SourceCode.Chasm.IO.Bond/Wire/TreeWireNodeExtensions.cs
+++ b/src/SourceCode.Chasm.IO.Bond/Wire/TreeWireNodeExtensions.cs
@@ -7,7 +7,7 @@
             if (wire == null) return 0;
 
             // Name
-            var len = 2 * (wire.Name?.Length ?? 0); // utf8
+            var len = (wire.Name?.Length ?? 0) * 3; // Utf8 is 1-3 bpc
 
             // Kind
             len += 4;

--- a/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Commit.cs
+++ b/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Commit.cs
@@ -14,9 +14,11 @@ namespace SourceCode.Chasm.IO.Json
             var wire = model.Convert();
             var json = wire?.ToString() ?? "null";
 
-            var utf8 = Encoding.UTF8.GetBytes(json);
+            var rented = BufferSession.RentBuffer(json.Length * 3); // Utf8 is 1-3 bpc
+            var count = Encoding.UTF8.GetBytes(json, 0, json.Length, rented, 0);
 
-            var session = new BufferSession(new ArraySegment<byte>(utf8));
+            var seg = new ArraySegment<byte>(rented, 0, count);
+            var session = new BufferSession(seg);
             return session;
         }
 

--- a/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Sha1.cs
+++ b/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Sha1.cs
@@ -10,10 +10,13 @@ namespace SourceCode.Chasm.IO.Json
 
         public override BufferSession Serialize(Sha1 model)
         {
-            var wire = model.ToString("N");
-            var utf8 = Encoding.UTF8.GetBytes(wire);
+            var json = model.ToString("N");
 
-            var session = new BufferSession(new ArraySegment<byte>(utf8));
+            var rented = BufferSession.RentBuffer(json.Length * 3); // Utf8 is 1-3 bpc
+            var count = Encoding.UTF8.GetBytes(json, 0, json.Length, rented, 0);
+
+            var seg = new ArraySegment<byte>(rented, 0, count);
+            var session = new BufferSession(seg);
             return session;
         }
 

--- a/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Tree.cs
@@ -14,9 +14,11 @@ namespace SourceCode.Chasm.IO.Json
             var wire = model.Convert();
             var json = wire?.ToString() ?? "null";
 
-            var utf8 = Encoding.UTF8.GetBytes(json);
+            var rented = BufferSession.RentBuffer(json.Length * 3); // Utf8 is 1-3 bpc
+            var count = Encoding.UTF8.GetBytes(json, 0, json.Length, rented, 0);
 
-            var session = new BufferSession(new ArraySegment<byte>(utf8));
+            var seg = new ArraySegment<byte>(rented, 0, count);
+            var session = new BufferSession(seg);
             return session;
         }
 

--- a/src/SourceCode.Chasm/NodeKind.cs
+++ b/src/SourceCode.Chasm/NodeKind.cs
@@ -3,7 +3,9 @@
     public enum NodeKind : byte
     {
         None = 0, // Default
+
         Tree = 1,
+
         Blob = 2
     }
 }

--- a/src/SourceCode.Chasm/Sha1.cs
+++ b/src/SourceCode.Chasm/Sha1.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -177,13 +178,19 @@ namespace SourceCode.Chasm
         /// <returns></returns>
         public static Sha1 Hash(string utf8)
         {
-            if (utf8 == null)
-                return Empty;
+            if (utf8 == null) return Empty;
+            // Note that length=0 should not short-circuit
 
-            var bytes = Encoding.UTF8.GetBytes(utf8);
-            var hash = _sha1.Value.ComputeHash(bytes);
+            // Rent buffer
+            var rented = ArrayPool<byte>.Shared.Rent(utf8.Length * 3); // Utf8 is 1-3 bpc
+            var count = Encoding.UTF8.GetBytes(utf8, 0, utf8.Length, rented, 0);
 
+            var hash = _sha1.Value.ComputeHash(rented, 0, count);
             var sha1 = new Sha1(hash);
+
+            // Return buffer
+            ArrayPool<byte>.Shared.Return(rented);
+
             return sha1;
         }
 
@@ -194,8 +201,8 @@ namespace SourceCode.Chasm
         /// <returns></returns>
         public static Sha1 Hash(byte[] bytes)
         {
-            if (bytes == null) // Note that length=0 should not short-circuit
-                return Empty;
+            if (bytes == null) return Empty;
+            // Note that length=0 should not short-circuit
 
             var hash = _sha1.Value.ComputeHash(bytes);
 
@@ -212,8 +219,8 @@ namespace SourceCode.Chasm
         /// <returns></returns>
         public static Sha1 Hash(byte[] bytes, int offset, int count)
         {
-            if (bytes == null) // Note that length=0 should not short-circuit
-                return Empty;
+            if (bytes == null) return Empty;
+            // Note that length=0 should not short-circuit
 
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -234,8 +241,8 @@ namespace SourceCode.Chasm
         /// <returns></returns>
         public static Sha1 Hash(ArraySegment<byte> bytes)
         {
-            if (bytes.Array == null) // Note that length=0 should not short-circuit
-                return Empty;
+            if (bytes.Array == null) return Empty;
+            // Note that length=0 should not short-circuit
 
             var hash = _sha1.Value.ComputeHash(bytes.Array, bytes.Offset, bytes.Count);
 
@@ -250,8 +257,8 @@ namespace SourceCode.Chasm
         /// <returns></returns>
         public static Sha1 Hash(Stream stream)
         {
-            if (stream == null)
-                return Empty;
+            if (stream == null) return Empty;
+            // Note that length=0 should not short-circuit
 
             var hash = _sha1.Value.ComputeHash(stream);
 

--- a/src/SourceCode.Chasm/Sha1.cs
+++ b/src/SourceCode.Chasm/Sha1.cs
@@ -37,7 +37,7 @@ namespace SourceCode.Chasm
         public const byte ByteLen = 20;
 
         /// <summary>
-        /// The number of characters required to represent a <see cref="Sha1"/> value.
+        /// The number of hex characters required to represent a <see cref="Sha1"/> value.
         /// </summary>
         public const byte CharLen = ByteLen * 2; // 40
 

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -31,6 +31,5 @@
     </PackageReference>
     <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00144" />
     <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00144" />
-    <PackageReference Include="System.Memory" Version="4.5.0-preview2-25707-02" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #23 
- UTF8 is 1-3 bytes per character (not 1-2)
- Use rented buffers where possible
- Units