### PR TITLE
Change TreeNodeList back to struct

### DIFF
--- a/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm.IO.Json/JsonChasmSerializer.Tree.cs
@@ -11,8 +11,6 @@ namespace SourceCode.Chasm.IO.Json
 
         public override BufferSession Serialize(TreeNodeList model)
         {
-            if (model == null) throw new ArgumentNullException(nameof(model));
-
             var wire = model.Convert();
             var json = wire?.ToString() ?? "null";
 

--- a/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
+++ b/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00158" />
+    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00166" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm.IO.Json/Wire/TreeWireExtensions.cs
+++ b/src/SourceCode.Chasm.IO.Json/Wire/TreeWireExtensions.cs
@@ -22,7 +22,7 @@ namespace SourceCode.Chasm.IO.Json.Wire
         public static TreeNodeList ConvertTree(this JsonArray wire)
         {
             if (wire == null) return default;
-            if (wire.Count == 0) return new TreeNodeList();
+            if (wire.Count == 0) return default;
 
             var nodes = new TreeNode[wire.Count];
             for (var i = 0; i < nodes.Length; i++)

--- a/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Tree.cs
+++ b/src/SourceCode.Chasm.IO.Proto/ProtoChasmSerializer.Tree.cs
@@ -11,11 +11,7 @@ namespace SourceCode.Chasm.IO.Proto
 
         public override BufferSession Serialize(TreeNodeList model)
         {
-            if (model == null) throw new ArgumentNullException(nameof(model));
-
             var wire = model.Convert();
-            if (wire == null)
-                return new BufferSession(Array.Empty<byte>(), new ArraySegment<byte>(Array.Empty<byte>(), 0, 0));
 
             var size = wire.CalculateSize();
             var buffer = BufferSession.RentBuffer(size);
@@ -37,7 +33,7 @@ namespace SourceCode.Chasm.IO.Proto
 
         public override TreeNodeList DeserializeTree(ReadOnlySpan<byte> span)
         {
-            if (span.IsEmpty) return new TreeNodeList();
+            if (span.IsEmpty) return default;
 
             var wire = new TreeWire();
             wire.MergeFrom(span.ToArray()); // TODO: Perf

--- a/src/SourceCode.Chasm.IO.Proto/Wire/TreeWireExtensions.cs
+++ b/src/SourceCode.Chasm.IO.Proto/Wire/TreeWireExtensions.cs
@@ -7,7 +7,6 @@ namespace SourceCode.Chasm.IO.Proto.Wire
     {
         public static TreeWire Convert(this TreeNodeList model)
         {
-            if (model == null) return null;
             if (model.Count == 0) return new TreeWire();
 
             var wire = new TreeWire();
@@ -23,7 +22,7 @@ namespace SourceCode.Chasm.IO.Proto.Wire
         public static TreeNodeList Convert(this TreeWire wire)
         {
             if (wire == null) return default;
-            if (wire.Nodes.Count == 0) return new TreeNodeList();
+            if (wire.Nodes.Count == 0) return default;
 
             var nodes = new TreeNode[wire.Nodes?.Count ?? 0];
             for (var i = 0; i < nodes.Length; i++)

--- a/src/SourceCode.Chasm.IO.Tests/NodeTests.cs
+++ b/src/SourceCode.Chasm.IO.Tests/NodeTests.cs
@@ -2,7 +2,7 @@
 
 namespace SourceCode.Chasm.IO.Tests
 {
-    public static class NodeFixtures
+    public static class NodeTests
     {
         [Trait("Type", "Unit")]
         [Theory(DisplayName = nameof(ChasmSerializer_WriteRead_NullTreeNodeList))]

--- a/src/SourceCode.Chasm.IO.Tests/SourceCode.Chasm.IO.Tests.csproj
+++ b/src/SourceCode.Chasm.IO.Tests/SourceCode.Chasm.IO.Tests.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit" Version="2.3.0-rc1-build3809" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-rc1-build3809" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm.IO.Tests/TreeNodeListTests.cs
+++ b/src/SourceCode.Chasm.IO.Tests/TreeNodeListTests.cs
@@ -15,7 +15,11 @@ namespace SourceCode.Chasm.IO.Tests
         public static void ChasmSerializer_Roundtrip_TreeNodeList_Default(IChasmSerializer ser)
         {
             TreeNodeList expected = default;
-            Assert.Throws<ArgumentNullException>(() => ser.Serialize(expected));
+            using (var buf = ser.Serialize(expected))
+            {
+                var actual = ser.DeserializeTree(buf.Result);
+                Assert.Equal(expected, actual);
+            }
         }
 
         [Trait("Type", "Unit")]
@@ -49,7 +53,7 @@ namespace SourceCode.Chasm.IO.Tests
         [ClassData(typeof(TestData))]
         public static void ChasmSerializer_Roundtrip_TreeNodeList_Empty_Array(IChasmSerializer ser)
         {
-            var expected = new TreeNodeList(Array.Empty<TreeNode>());
+            var expected = new TreeNodeList();
             using (var buf = ser.Serialize(expected))
             {
                 var actual = ser.DeserializeTree(buf.Result);

--- a/src/SourceCode.Chasm.Tests/SourceCode.Chasm.Tests.csproj
+++ b/src/SourceCode.Chasm.Tests/SourceCode.Chasm.Tests.csproj
@@ -18,8 +18,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="Moq" Version="4.7.127" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit" Version="2.3.0-rc1-build3809" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-rc1-build3809" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm.Tests/TreeNodeListTests.cs
+++ b/src/SourceCode.Chasm.Tests/TreeNodeListTests.cs
@@ -19,15 +19,20 @@ namespace SourceCode.Chasm.Tests
             var nullData = new TreeNodeList(null);
             var emptyData = new TreeNodeList(Array.Empty<TreeNode>());
 
-            Assert.Equal(noData, nullData);
-            Assert.Equal(noData.GetHashCode(), nullData.GetHashCode());
+            Assert.Empty(TreeNodeList.Empty);
+            Assert.Equal(default, TreeNodeList.Empty);
 
             Assert.Empty(noData);
-            Assert.Empty(nullData);
-            Assert.Empty(emptyData);
+            Assert.Equal(TreeNodeList.Empty, noData); // By design
+            Assert.Equal(TreeNodeList.Empty.GetHashCode(), noData.GetHashCode());
 
-            Assert.Equal(noData, emptyData); // By design
-            Assert.Equal(noData.GetHashCode(), emptyData.GetHashCode());
+            Assert.Empty(nullData);
+            Assert.Equal(TreeNodeList.Empty, nullData); // By design
+            Assert.Equal(TreeNodeList.Empty.GetHashCode(), nullData.GetHashCode());
+
+            Assert.Empty(emptyData);
+            Assert.Equal(TreeNodeList.Empty, emptyData); // By design
+            Assert.Equal(TreeNodeList.Empty.GetHashCode(), emptyData.GetHashCode());
         }
 
         [Trait("Type", "Unit")]

--- a/src/SourceCode.Chasm/Blob.cs
+++ b/src/SourceCode.Chasm/Blob.cs
@@ -1,5 +1,4 @@
-﻿using SourceCode.Clay.Buffers;
-using System;
+﻿using System;
 
 namespace SourceCode.Chasm
 {
@@ -33,26 +32,23 @@ namespace SourceCode.Chasm
 
         #region IEquatable
 
-        public bool Equals(Blob other)
-            => BufferComparer.Array.Equals(Data, other.Data);
+        public bool Equals(Blob other) => BlobComparer.Default.Equals(this, other);
 
         public override bool Equals(object obj)
             => obj is Blob blob
-            && Equals(blob);
+            && BlobComparer.Default.Equals(blob);
 
-        public override int GetHashCode()
-            => BufferComparer.Array.GetHashCode(Data);
-
-        public static bool operator ==(Blob x, Blob y) => x.Equals(y);
-
-        public static bool operator !=(Blob x, Blob y) => !x.Equals(y);
+        public override int GetHashCode() => BlobComparer.Default.GetHashCode(this);
 
         #endregion
 
         #region Operators
 
-        public override string ToString()
-            => $"{nameof(Blob)}: {Data?.Length ?? 0}";
+        public static bool operator ==(Blob x, Blob y) => BlobComparer.Default.Equals(x, y);
+
+        public static bool operator !=(Blob x, Blob y) => !BlobComparer.Default.Equals(x, y); // not
+
+        public override string ToString() => $"{nameof(Blob)}: {Data?.Length ?? 0}";
 
         #endregion
     }

--- a/src/SourceCode.Chasm/BlobComparer.cs
+++ b/src/SourceCode.Chasm/BlobComparer.cs
@@ -1,0 +1,51 @@
+﻿using SourceCode.Clay.Buffers;
+using System.Collections.Generic;
+
+namespace SourceCode.Chasm
+{
+    /// <summary>
+    /// Represents a way to compare different <see cref="Blob"/> values.
+    /// </summary>
+    public abstract class BlobComparer : IEqualityComparer<Blob>
+    {
+        #region Constants
+
+        /// <summary>
+        /// Gets a <see cref="BlobComparer"/> that compares all fields of a <see cref="Blob"/> value.
+        /// </summary>
+        public static BlobComparer Default { get; } = new DefaultComparer();
+
+        #endregion
+
+        #region Constructors
+
+        protected BlobComparer()
+        { }
+
+        #endregion
+
+        #region IEqualityComparer
+
+        /// <inheritdoc/>
+        public abstract bool Equals(Blob x, Blob y);
+
+        /// <inheritdoc/>
+        public abstract int GetHashCode(Blob obj);
+
+        #endregion
+
+        #region Concrete
+
+        private sealed class DefaultComparer : BlobComparer
+        {
+            internal DefaultComparer()
+            { }
+
+            public override bool Equals(Blob x, Blob y) => BufferComparer.Array.Equals(x.Data, y.Data);
+
+            public override int GetHashCode(Blob obj) => BufferComparer.Array.GetHashCode(obj.Data);
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm/BlobId.cs
+++ b/src/SourceCode.Chasm/BlobId.cs
@@ -6,6 +6,12 @@ namespace SourceCode.Chasm
     {
         #region Constants
 
+        /// <summary>
+        /// A singleton representing an empty <see cref="BlobId"/> value.
+        /// </summary>
+        /// <value>
+        /// The empty.
+        /// </value>
         public static BlobId Empty { get; }
 
         #endregion

--- a/src/SourceCode.Chasm/Commit.cs
+++ b/src/SourceCode.Chasm/Commit.cs
@@ -22,7 +22,7 @@ namespace SourceCode.Chasm
 
         #region Fields
 
-        private readonly IReadOnlyList<CommitId> _parents;
+        private readonly IReadOnlyList<CommitId> _parents; // May be null due to default ctor
         private readonly string _message;
 
         #endregion

--- a/src/SourceCode.Chasm/Commit.cs
+++ b/src/SourceCode.Chasm/Commit.cs
@@ -8,6 +8,12 @@ namespace SourceCode.Chasm
     {
         #region Constants
 
+        /// <summary>
+        /// A singleton representing an empty <see cref="Commit"/> value.
+        /// </summary>
+        /// <value>
+        /// The empty.
+        /// </value>
         public static Commit Empty { get; }
 
         public static CommitId[] Orphaned { get; } = new[] { CommitId.Empty };

--- a/src/SourceCode.Chasm/CommitId.cs
+++ b/src/SourceCode.Chasm/CommitId.cs
@@ -6,6 +6,12 @@ namespace SourceCode.Chasm
     {
         #region Constants
 
+        /// <summary>
+        /// A singleton representing an empty <see cref="CommitId"/> value.
+        /// </summary>
+        /// <value>
+        /// The empty.
+        /// </value>
         public static CommitId Empty { get; }
 
         #endregion

--- a/src/SourceCode.Chasm/CommitRef.cs
+++ b/src/SourceCode.Chasm/CommitRef.cs
@@ -6,6 +6,12 @@ namespace SourceCode.Chasm
     {
         #region Constants
 
+        /// <summary>
+        /// A singleton representing an empty <see cref="CommitRef"/> value.
+        /// </summary>
+        /// <value>
+        /// The empty.
+        /// </value>
         public static CommitRef Empty { get; }
 
         #endregion

--- a/src/SourceCode.Chasm/IO/ChasmRepository.Tree.cs
+++ b/src/SourceCode.Chasm/IO/ChasmRepository.Tree.cs
@@ -179,7 +179,7 @@ namespace SourceCode.Chasm.IO
             if (commitUtc.Kind != DateTimeKind.Utc) throw new ArgumentException(nameof(commitUtc));
 
             var treeId = TreeId.Empty;
-            if (tree != null && tree.Count > 0)
+            if (tree.Count > 0)
                 treeId = WriteTree(tree, forceOverwrite);
 
             var commit = new Commit(parents, treeId, commitUtc, commitMessage);
@@ -193,7 +193,7 @@ namespace SourceCode.Chasm.IO
             if (commitUtc.Kind != DateTimeKind.Utc) throw new ArgumentException(nameof(commitUtc));
 
             var treeId = TreeId.Empty;
-            if (tree != null && tree.Count > 0)
+            if (tree.Count > 0)
                 treeId = await WriteTreeAsync(tree, forceOverwrite, cancellationToken).ConfigureAwait(false);
 
             var commit = new Commit(parents, treeId, commitUtc, commitMessage);

--- a/src/SourceCode.Chasm/IO/ChasmRepository.Tree.cs
+++ b/src/SourceCode.Chasm/IO/ChasmRepository.Tree.cs
@@ -12,12 +12,11 @@ namespace SourceCode.Chasm.IO
 
         public TreeNodeList ReadTree(TreeId treeId)
         {
-            if (treeId == TreeId.Empty) return new TreeNodeList();
+            if (treeId == TreeId.Empty) return default;
 
             // Read bytes
             var buffer = ReadObject(treeId.Sha1);
-            if (buffer.IsEmpty)
-                return new TreeNodeList();
+            if (buffer.IsEmpty) return default;
 
             // Deserialize
             var tree = Serializer.DeserializeTree(buffer.Span);
@@ -26,12 +25,11 @@ namespace SourceCode.Chasm.IO
 
         public async ValueTask<TreeNodeList> ReadTreeAsync(TreeId treeId, CancellationToken cancellationToken)
         {
-            if (treeId == TreeId.Empty) return new TreeNodeList();
+            if (treeId == TreeId.Empty) return default;
 
             // Read bytes
             var buffer = await ReadObjectAsync(treeId.Sha1, cancellationToken).ConfigureAwait(false);
-            if (buffer.IsEmpty)
-                return new TreeNodeList();
+            if (buffer.IsEmpty) return default;
 
             // Deserialize
             var tree = Serializer.DeserializeTree(buffer.Span);
@@ -90,8 +88,7 @@ namespace SourceCode.Chasm.IO
 
             // CommitRef
             var commitId = ReadCommitRef(branch, commitRefName);
-            if (commitId == CommitId.Empty)
-                return new TreeNodeList();
+            if (commitId == CommitId.Empty) return default;
 
             // Tree
             var tree = ReadTree(commitId);
@@ -105,8 +102,7 @@ namespace SourceCode.Chasm.IO
 
             // CommitRef
             var commitId = await ReadCommitRefAsync(branch, commitRefName, cancellationToken).ConfigureAwait(false);
-            if (commitId == CommitId.Empty)
-                return new TreeNodeList();
+            if (commitId == CommitId.Empty) return default;
 
             // Tree
             var tree = await ReadTreeAsync(commitId, cancellationToken).ConfigureAwait(false);
@@ -119,12 +115,11 @@ namespace SourceCode.Chasm.IO
 
         public virtual TreeNodeList ReadTree(CommitId commitId)
         {
-            if (commitId == CommitId.Empty) return new TreeNodeList();
+            if (commitId == CommitId.Empty) return default;
 
             // Commit
             var commit = ReadCommit(commitId);
-            if (commit == Commit.Empty)
-                return new TreeNodeList();
+            if (commit == Commit.Empty) return default;
 
             // Tree
             var tree = ReadTree(commit.TreeId);
@@ -133,7 +128,7 @@ namespace SourceCode.Chasm.IO
 
         public virtual async ValueTask<TreeNodeList> ReadTreeAsync(CommitId commitId, CancellationToken cancellationToken)
         {
-            if (commitId == CommitId.Empty) return new TreeNodeList();
+            if (commitId == CommitId.Empty) return default;
 
             // Commit
             var commit = await ReadCommitAsync(commitId, cancellationToken).ConfigureAwait(false); ;

--- a/src/SourceCode.Chasm/Sha1Comparer.cs
+++ b/src/SourceCode.Chasm/Sha1Comparer.cs
@@ -69,7 +69,18 @@ namespace SourceCode.Chasm
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override int GetHashCode(Sha1 obj)
-                => (int)obj.Blit0;
+            {
+                var h = 11L;
+
+                unchecked
+                {
+                    h = h * 7 + (long)obj.Blit0;
+                    h = h * 7 + (long)obj.Blit1;
+                    h = h * 7 + obj.Blit2;
+                }
+
+                return (int)h;
+            }
         }
 
         #endregion

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00158" />
-    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00158" />
+    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00166" />
+    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00166" />
   </ItemGroup>
 </Project>

--- a/src/SourceCode.Chasm/TreeId.cs
+++ b/src/SourceCode.Chasm/TreeId.cs
@@ -6,6 +6,12 @@ namespace SourceCode.Chasm
     {
         #region Constants
 
+        /// <summary>
+        /// A singleton representing an empty <see cref="TreeId"/> value.
+        /// </summary>
+        /// <value>
+        /// The empty.
+        /// </value>
         public static TreeId Empty { get; }
 
         #endregion

--- a/src/SourceCode.Chasm/TreeNode.cs
+++ b/src/SourceCode.Chasm/TreeNode.cs
@@ -6,10 +6,28 @@ namespace SourceCode.Chasm
     {
         #region Constants
 
+        /// <summary>
+        /// A singleton representing an empty <see cref="TreeNode"/> value.
+        /// </summary>
+        /// <value>
+        /// The empty.
+        /// </value>
         public static TreeNode Empty { get; }
 
+        /// <summary>
+        /// A singleton representing an empty <see cref="TreeNode"/> value with <see cref="Kind"/> set to <see cref="NodeKind.Blob"/>.
+        /// </summary>
+        /// <value>
+        /// The empty.
+        /// </value>
         public static TreeNode EmptyBlob { get; } = new TreeNode(null, Sha1.Empty, NodeKind.Blob);
 
+        /// <summary>
+        /// A singleton representing an empty <see cref="TreeNode"/> value with <see cref="Kind"/> set to <see cref="NodeKind.Tree"/>.
+        /// </summary>
+        /// <value>
+        /// The empty.
+        /// </value>
         public static TreeNode EmptyTree { get; } = new TreeNode(null, Sha1.Empty, NodeKind.Tree);
 
         #endregion

--- a/src/SourceCode.Chasm/TreeNodeList.cs
+++ b/src/SourceCode.Chasm/TreeNodeList.cs
@@ -6,11 +6,17 @@ using System.Diagnostics;
 namespace SourceCode.Chasm
 {
     [DebuggerDisplay("Count = {" + nameof(Count) + "}")]
-    public sealed class TreeNodeList : IReadOnlyDictionary<string, TreeNode>, IReadOnlyList<TreeNode>, IEquatable<TreeNodeList>
+    public struct TreeNodeList : IReadOnlyDictionary<string, TreeNode>, IReadOnlyList<TreeNode>, IEquatable<TreeNodeList>
     {
         #region Constants
 
-        //
+        /// <summary>
+        /// A singleton representing an empty <see cref="TreeNodeList"/> value.
+        /// </summary>
+        /// <value>
+        /// The empty.
+        /// </value>
+        public static TreeNodeList Empty { get; }
 
         #endregion
 

--- a/src/SourceCode.Chasm/TreeNodeList.cs
+++ b/src/SourceCode.Chasm/TreeNodeList.cs
@@ -444,8 +444,8 @@ namespace SourceCode.Chasm
         public bool Equals(TreeNodeList other) => TreeNodeListComparer.Default.Equals(this, other);
 
         public override bool Equals(object obj)
-            => obj is TreeNodeList tnl
-            && TreeNodeListComparer.Default.Equals(this, tnl);
+            => obj is TreeNodeList tree
+            && TreeNodeListComparer.Default.Equals(this, tree);
 
         public override int GetHashCode() => TreeNodeListComparer.Default.GetHashCode(this);
 

--- a/src/SourceCode.Chasm/TreeNodeList.cs
+++ b/src/SourceCode.Chasm/TreeNodeList.cs
@@ -22,7 +22,7 @@ namespace SourceCode.Chasm
 
         #region Fields
 
-        internal readonly TreeNode[] _nodes;
+        internal readonly TreeNode[] _nodes; // May be null due to default ctor
 
         #endregion
 
@@ -33,7 +33,7 @@ namespace SourceCode.Chasm
             get
             {
                 if (_nodes == null)
-                    return Array.Empty<TreeNode>()[index]; // Leverage underlying exception
+                    return Array.Empty<TreeNode>()[index]; // Throw underlying exception
 
                 return _nodes[index];
             }
@@ -56,28 +56,20 @@ namespace SourceCode.Chasm
 
         #region Constructors
 
-        public TreeNodeList()
-        {
-            // Coerce null to empty
-            _nodes = Array.Empty<TreeNode>();
-        }
-
         public TreeNodeList(params TreeNode[] nodes)
         {
-            // Coerce null to empty
-            if (nodes == null)
+            // Coerce null to null
+            if (nodes == null || nodes.Length == 0)
             {
-                _nodes = Array.Empty<TreeNode>();
+                // We choose to coerce empty & null to null, so that serialization round-trips properly.
+                // (May be null due to default ctor)
+                _nodes = null;
                 return;
             }
 
             // Optimize for common cases 0, 1, 2, N
             switch (nodes.Length)
             {
-                case 0:
-                    _nodes = Array.Empty<TreeNode>();
-                    return;
-
                 case 1:
                     _nodes = new TreeNode[1] { nodes[0] };
                     return;
@@ -138,19 +130,18 @@ namespace SourceCode.Chasm
 
         public TreeNodeList(ICollection<TreeNode> nodes)
         {
-            if (nodes == null)
+            // Coerce null to null
+            if (nodes == null || nodes.Count == 0)
             {
-                _nodes = Array.Empty<TreeNode>();
+                // We choose to coerce empty & null to null, so that serialization round-trips properly.
+                // (May be null due to default ctor)
+                _nodes = null;
                 return;
             }
 
             // Optimize for common cases 0, 1, 2, N
             switch (nodes.Count)
             {
-                case 0:
-                    _nodes = Array.Empty<TreeNode>();
-                    return;
-
                 case 1:
                     using (var enm = nodes.GetEnumerator())
                     {
@@ -439,7 +430,8 @@ namespace SourceCode.Chasm
 
         IEnumerator<KeyValuePair<string, TreeNode>> IEnumerable<KeyValuePair<string, TreeNode>>.GetEnumerator()
         {
-            if (_nodes == null) yield break;
+            if (_nodes == null || _nodes.Length == 0)
+                yield break;
 
             foreach (var item in _nodes)
                 yield return new KeyValuePair<string, TreeNode>(item.Name, item);

--- a/src/SourceCode.Chasm/TreeNodeListComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeListComparer.cs
@@ -43,8 +43,6 @@ namespace SourceCode.Chasm
 
             public override bool Equals(TreeNodeList x, TreeNodeList y)
             {
-                if (ReferenceEquals(x, y)) return true; // (x, x) or (null, null)
-                if (ReferenceEquals(x, null) || ReferenceEquals(y, null)) return false; // (x, null) or (null, y)
                 if (!x._nodes.NullableEquals(y._nodes, true)) return false;
 
                 return true;


### PR DESCRIPTION
- Reverts #17 
Made a cleaner fix for serialization round-tripping that allows us to keep `TreeNodeList` as a `struct`:
All explicit constructors coerce `empty` and `null` collections of nodes to `null`.
Thus, the default `struct` ctor has the same behavior.

Internal code has to deal with `null` nodes appropriately.