### PR TITLE
Nuget & alignment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,9 @@
+﻿# http://editorconfig.org
+root = true
+
+# All files
 [*]
+charset = utf-8
 end_of_line = crlf
 
 # CSharp code style settings:

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@
 >It is typically used for high-speed storage and retrieval of fixed content"
 
 [Git](https://en.wikipedia.org/wiki/Git) is a well-known example of a product that uses CAS.
+However Chasm does not aim to be a Git replacement. For example, there is no concept of a working tree.
+Rather, this is meant to be a general purpose CAS store for any document type.
 
 ### Requirements
 
 * CAS: Self-versioned, immutable store. 
 * Single-instance storage of data: If two authors create the exact same documents, their repos should not differ in Object data.
-* Efficient network/disk operations: XML is bad, JSON is better, Bond/Protobuf/etc are best
+* Efficient network/disk operations: XML is bad, JSON is better, Protobuf/etc are best
 * Simple: Avoid the need to reinvent graph semantics, etc
 
 ### Getting started

--- a/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
+++ b/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00172" />
+    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00175" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
+++ b/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00169" />
+    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00172" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
+++ b/src/SourceCode.Chasm.IO.Json/SourceCode.Chasm.IO.Json.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00166" />
+    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00169" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm.IO.Json/Wire/TreeWireExtensions.cs
+++ b/src/SourceCode.Chasm.IO.Json/Wire/TreeWireExtensions.cs
@@ -8,7 +8,6 @@ namespace SourceCode.Chasm.IO.Json.Wire
     {
         public static JsonValue Convert(this TreeNodeList model)
         {
-            if (model == null) return default;
             if (model.Count == 0) return new JsonArray(Array.Empty<JsonValue>());
 
             var items = new JsonValue[model.Count];

--- a/src/SourceCode.Chasm.IO.Proto/Wire/CommitWireExtensions.cs
+++ b/src/SourceCode.Chasm.IO.Proto/Wire/CommitWireExtensions.cs
@@ -16,30 +16,27 @@ namespace SourceCode.Chasm.IO.Proto.Wire
             var wire = new CommitWire();
 
             // Parents
-            if (model.Parents != null)
+            switch (model.Parents.Count)
             {
-                switch (model.Parents.Count)
-                {
-                    case 0:
-                        break;
+                case 0:
+                    break;
 
-                    case 1:
+                case 1:
+                    {
+                        var sha1 = model.Parents[0].Sha1.Convert();
+                        wire.Parents.Add(sha1);
+                    }
+                    break;
+
+                default:
+                    {
+                        foreach (var parent in model.Parents)
                         {
-                            var sha1 = model.Parents[0].Sha1.Convert();
+                            var sha1 = parent.Sha1.Convert();
                             wire.Parents.Add(sha1);
                         }
-                        break;
-
-                    default:
-                        {
-                            foreach (var parent in model.Parents)
-                            {
-                                var sha1 = parent.Sha1.Convert();
-                                wire.Parents.Add(sha1);
-                            }
-                        }
-                        break;
-                }
+                    }
+                    break;
             }
 
             // CommitUtc

--- a/src/SourceCode.Chasm.Tests/CommitTests.cs
+++ b/src/SourceCode.Chasm.Tests/CommitTests.cs
@@ -128,15 +128,15 @@ namespace SourceCode.Chasm.Tests
         public static void Commit_Parents_1_Empty()
         {
             var actual = new Commit(CommitId.Empty, default, default, null);
-            Assert.Equal(CommitId.Empty, actual.Parents[0]);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, CommitId.Empty));
         }
 
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(Commit_Parents_1))]
         public static void Commit_Parents_1()
         {
-            var actual = new Commit(Parent1, default, default, null);
-            Assert.Equal(Parent1, actual.Parents[0]);
+            var actual = new Commit(Parent2, default, default, null);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, Parent2));
         }
 
         [Trait("Type", "Unit")]
@@ -144,7 +144,7 @@ namespace SourceCode.Chasm.Tests
         public static void Commit_Parents_2_Empty_Duplicated()
         {
             var actual = new Commit(new[] { CommitId.Empty, CommitId.Empty }, default, default, null);
-            Assert.Equal(1, actual.Parents.Count);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, CommitId.Empty));
             Assert.Equal(CommitId.Empty, actual.Parents[0]);
         }
 
@@ -152,9 +152,9 @@ namespace SourceCode.Chasm.Tests
         [Fact(DisplayName = nameof(Commit_Parents_2_Duplicated))]
         public static void Commit_Parents_2_Duplicated()
         {
-            var actual = new Commit(new[] { Parent1, Parent1 }, default, default, null);
-            Assert.Equal(1, actual.Parents.Count);
-            Assert.Equal(Parent1, actual.Parents[0]);
+            var actual = new Commit(new[] { Parent2, Parent2 }, default, default, null);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, Parent2));
+            Assert.Equal(Parent2, actual.Parents[0]);
         }
 
         [Trait("Type", "Unit")]
@@ -165,13 +165,13 @@ namespace SourceCode.Chasm.Tests
             var parents = new[] { Parent1, Parent2 }.OrderByDescending(n => n.Sha1).ToArray();
 
             var actual = new Commit(parents, default, default, null);
-            Assert.Equal(2, actual.Parents.Count);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, Parent1), n => Assert.Equal(n, Parent2));
 
             // Reversed
             Array.Reverse(parents);
 
             var actual2 = new Commit(parents, default, default, null);
-            Assert.Equal(actual, actual2);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, Parent1), n => Assert.Equal(n, Parent2));
         }
 
         [Trait("Type", "Unit")]
@@ -179,7 +179,7 @@ namespace SourceCode.Chasm.Tests
         public static void Commit_Parents_3_Empty_Duplicated()
         {
             var actual = new Commit(new[] { CommitId.Empty, CommitId.Empty, CommitId.Empty }, default, default, null);
-            Assert.Equal(1, actual.Parents.Count);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, CommitId.Empty));
         }
 
         [Trait("Type", "Unit")]
@@ -188,15 +188,15 @@ namespace SourceCode.Chasm.Tests
         {
             // 3 duplicates
             var actual = new Commit(new[] { Parent1, Parent1, Parent1 }, default, default, null);
-            Assert.Equal(1, actual.Parents.Count);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, Parent1));
 
             // 2 duplicates
             actual = new Commit(new[] { Parent1, Parent2, Parent1 }, default, default, null);
-            Assert.Equal(2, actual.Parents.Count);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, Parent1), n => Assert.Equal(n, Parent2));
 
             // 2x2 duplicates
             actual = new Commit(new[] { Parent1, Parent2, Parent1, Parent2 }, default, default, null);
-            Assert.Equal(2, actual.Parents.Count);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, Parent1), n => Assert.Equal(n, Parent2));
         }
 
         [Trait("Type", "Unit")]
@@ -207,12 +207,31 @@ namespace SourceCode.Chasm.Tests
             var parents = new[] { Parent1, Parent2, Parent3 }.OrderByDescending(n => n.Sha1).ToArray();
 
             var actual = new Commit(parents, default, default, null);
-            Assert.Equal(3, actual.Parents.Count);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, Parent3), n => Assert.Equal(n, Parent1), n => Assert.Equal(n, Parent2));
 
             // Reversed
             Array.Reverse(parents);
 
             var actual2 = new Commit(parents, default, default, null);
+            Assert.Collection(actual2.Parents, n => Assert.Equal(n, Parent3), n => Assert.Equal(n, Parent1), n => Assert.Equal(n, Parent2));
+            Assert.Equal(actual, actual2);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(Commit_Parents_N_Duplicated))]
+        public static void Commit_Parents_N_Duplicated()
+        {
+            // Forward
+            var parents = new[] { Parent2, Parent1, Parent3, Parent2, Parent3, Parent1, Parent2, Parent3, Parent3, Parent1 };
+
+            var actual = new Commit(parents, default, default, null);
+            Assert.Collection(actual.Parents, n => Assert.Equal(n, Parent3), n => Assert.Equal(n, Parent1), n => Assert.Equal(n, Parent2));
+
+            // Reversed
+            Array.Reverse(parents);
+
+            var actual2 = new Commit(parents, default, default, null);
+            Assert.Collection(actual2.Parents, n => Assert.Equal(n, Parent3), n => Assert.Equal(n, Parent1), n => Assert.Equal(n, Parent2));
             Assert.Equal(actual, actual2);
         }
     }

--- a/src/SourceCode.Chasm.Tests/TreeNodeListTests.cs
+++ b/src/SourceCode.Chasm.Tests/TreeNodeListTests.cs
@@ -65,22 +65,78 @@ namespace SourceCode.Chasm.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(TreeNodeList_Duplicates))]
-        public static void TreeNodeList_Duplicates()
+        [Fact(DisplayName = nameof(TreeNodeList_Duplicate_Full_2))]
+        public static void TreeNodeList_Duplicate_Full_2()
         {
             var nodes = new[] { Node0, Node0 };
+
+            var tree = new TreeNodeList(nodes);
+            Assert.Collection<TreeNode>(tree, n => Assert.Equal(n, Node0));
+
+            tree = new TreeNodeList(nodes.ToList()); // ICollection<T>
+            Assert.Collection<TreeNode>(tree, n => Assert.Equal(n, Node0));
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeNodeList_Duplicate_Full_3))]
+        public static void TreeNodeList_Duplicate_Full_3()
+        {
+            var nodes = new[] { Node0, Node1, Node0 }; // Shuffled
+
+            var tree = new TreeNodeList(nodes);
+            Assert.Collection<TreeNode>(tree, n => Assert.Equal(n, Node0), n => Assert.Equal(n, Node1));
+
+            tree = new TreeNodeList(nodes.ToList()); // ICollection<T>
+            Assert.Collection<TreeNode>(tree, n => Assert.Equal(n, Node0), n => Assert.Equal(n, Node1));
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeNodeList_Duplicate_Full_4))]
+        public static void TreeNodeList_Duplicate_Full_4()
+        {
+            var nodes = new[] { Node0, Node2, Node1, Node0 }; // Shuffled
+
+            var tree = new TreeNodeList(nodes);
+            Assert.Collection<TreeNode>(tree, n => Assert.Equal(n, Node0), n => Assert.Equal(n, Node1), n => Assert.Equal(n, Node2));
+
+            tree = new TreeNodeList(nodes.ToList()); // ICollection<T>
+            Assert.Collection<TreeNode>(tree, n => Assert.Equal(n, Node0), n => Assert.Equal(n, Node1), n => Assert.Equal(n, Node2));
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeNodeList_Duplicate_Full_N))]
+        public static void TreeNodeList_Duplicate_Full_N()
+        {
+            var nodes = new[] { Node3, Node1, Node2, Node0, Node3, Node0, Node1, Node0, Node1, Node2, Node0, Node3 }; // Shuffled
+
+            var tree = new TreeNodeList(nodes);
+            Assert.Collection<TreeNode>(tree, n => Assert.Equal(n, Node0), n => Assert.Equal(n, Node1), n => Assert.Equal(n, Node2), n => Assert.Equal(n, Node3));
+
+            tree = new TreeNodeList(nodes.ToList()); // ICollection<T>
+            Assert.Collection<TreeNode>(tree, n => Assert.Equal(n, Node0), n => Assert.Equal(n, Node1), n => Assert.Equal(n, Node2), n => Assert.Equal(n, Node3));
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeNodeList_Duplicate_Name))]
+        public static void TreeNodeList_Duplicate_Name()
+        {
+            var nodes = new[] { new TreeNode(Node0.Name, NodeKind.Tree, Node1.Sha1), Node0 }; // Reversed
+
             Assert.Throws<ArgumentException>(() => new TreeNodeList(nodes));
             Assert.Throws<ArgumentException>(() => new TreeNodeList(nodes.ToList())); // ICollection<T>
+        }
 
-            nodes = new[] { Node0, Node1, Node0 };
-            Assert.Throws<ArgumentException>(() => new TreeNodeList(nodes));
-            Assert.Throws<ArgumentException>(() => new TreeNodeList(nodes.ToList())); // ICollection<T>
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(TreeNodeList_Duplicate_Sha1))]
+        public static void TreeNodeList_Duplicate_Sha1()
+        {
+            var nodes = new[] { new TreeNode(Node1.Name, NodeKind.Tree, Node0.Sha1), Node0 }; // Reversed
 
-            nodes = new[] { Node0, Node1, Node2, Node0 };
-            Assert.Throws<ArgumentException>(() => new TreeNodeList(nodes));
-            Assert.Throws<ArgumentException>(() => new TreeNodeList(nodes.ToList())); // ICollection<T>
+            var tree0 = new TreeNodeList(nodes);
+            Assert.Collection<TreeNode>(tree0, n => Assert.Equal(n, Node0), n => Assert.Equal(n, nodes[0]));
 
-            Assert.Throws<ArgumentException>(() => new TreeNodeList(Node0, new TreeNode(Node0.Name, NodeKind.Tree, Node1.Sha1))); // Duplicate Name
+            tree0 = new TreeNodeList(nodes.ToList()); // ICollection<T>
+            Assert.Collection<TreeNode>(tree0, n => Assert.Equal(n, Node0), n => Assert.Equal(n, nodes[0]));
         }
 
         [Trait("Type", "Unit")]
@@ -127,7 +183,7 @@ namespace SourceCode.Chasm.Tests
             var prev = list.Keys.First();
             foreach (var cur in list.Keys.Skip(1))
             {
-                Assert.True(StringComparer.Ordinal.Compare(cur, prev) > 0);
+                Assert.True(string.CompareOrdinal(cur, prev) > 0);
                 prev = cur;
             }
         }

--- a/src/SourceCode.Chasm/Commit.cs
+++ b/src/SourceCode.Chasm/Commit.cs
@@ -68,21 +68,19 @@ namespace SourceCode.Chasm
 
                 case 2:
                     {
-                        // Silently de-duplicate
-                        if (parents[0].Sha1 == parents[1].Sha1)
+                        var cmp = CommitIdComparer.Default.Compare(parents[0], parents[1]);
+                        switch (cmp)
                         {
-                            _parents = new CommitId[1] { parents[0] };
-                            return;
-                        }
+                            // Silently de-duplicate
+                            case 0: _parents = new CommitId[1] { parents[0] }; return;
 
-                        // Else sort
-                        var cmp = Sha1Comparer.Default.Compare(parents[0].Sha1, parents[1].Sha1);
-                        if (cmp < 0)
-                            _parents = new CommitId[2] { parents[0], parents[1] };
-                        else
-                            _parents = new CommitId[2] { parents[1], parents[0] };
+                            // Sort ascending
+                            case -1: _parents = new CommitId[2] { parents[0], parents[1] }; return;
+
+                            // Sort descending
+                            default: _parents = new CommitId[2] { parents[1], parents[0] }; return;
+                        }
                     }
-                    return;
 
                 default:
                     {

--- a/src/SourceCode.Chasm/Commit.cs
+++ b/src/SourceCode.Chasm/Commit.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace SourceCode.Chasm
@@ -74,10 +74,10 @@ namespace SourceCode.Chasm
                             // Silently de-duplicate
                             case 0: _parents = new CommitId[1] { parents[0] }; return;
 
-                            // Sort ascending
+                            // Sort forward
                             case -1: _parents = new CommitId[2] { parents[0], parents[1] }; return;
 
-                            // Sort descending
+                            // Sort reverse
                             default: _parents = new CommitId[2] { parents[1], parents[0] }; return;
                         }
                     }

--- a/src/SourceCode.Chasm/CommitComparer.cs
+++ b/src/SourceCode.Chasm/CommitComparer.cs
@@ -1,4 +1,4 @@
-﻿using SourceCode.Clay.Collections.Generic;
+using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
 
@@ -47,7 +47,7 @@ namespace SourceCode.Chasm
                 if (x.CommitUtc != y.CommitUtc) return false;
                 if (!x.TreeId.Equals(y.TreeId)) return false;
                 if (!StringComparer.Ordinal.Equals(x.CommitMessage, y.CommitMessage)) return false;
-                if (!x.Parents.NullableEquals(y.Parents, CommitIdComparer.Default, true)) return false;
+                if (!x.Parents.ListEquals(y.Parents, CommitIdComparer.Default, true)) return false;
 
                 return true;
             }

--- a/src/SourceCode.Chasm/Sha1Comparer.cs
+++ b/src/SourceCode.Chasm/Sha1Comparer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace SourceCode.Chasm
@@ -51,6 +51,8 @@ namespace SourceCode.Chasm
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override int Compare(Sha1 x, Sha1 y)
             {
+                // CLR returns [-1, 0, +1] for ulong/uint comparisons (vs arbitrary neg/pos values)
+
                 var cmp = x.Blit0.CompareTo(y.Blit0);
                 if (cmp != 0) return cmp;
 

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00166" />
-    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00166" />
+    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00169" />
+    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00169" />
   </ItemGroup>
 </Project>

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00172" />
-    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00172" />
+    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00175" />
+    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00175" />
   </ItemGroup>
 </Project>

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00169" />
-    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00169" />
+    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00172" />
+    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00172" />
   </ItemGroup>
 </Project>

--- a/src/SourceCode.Chasm/TreeNodeComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeComparer.cs
@@ -58,6 +58,7 @@ namespace SourceCode.Chasm
                 cmp = Sha1Comparer.Default.Compare(x.Sha1, y.Sha1);
                 if (cmp != 0) return cmp;
 
+                // And lastly by Kind
                 cmp = ((int)x.Kind).CompareTo((int)y.Kind);
                 return cmp;
             }

--- a/src/SourceCode.Chasm/TreeNodeList.cs
+++ b/src/SourceCode.Chasm/TreeNodeList.cs
@@ -76,12 +76,25 @@ namespace SourceCode.Chasm
 
                 case 2:
                     {
-                        // Throw if the Name is duplicated
+                        // If the Name alone is duplicated
+                        int cmp;
                         if (StringComparer.Ordinal.Equals(nodes[0].Name, nodes[1].Name))
+                        {
+                            // Check if it's a complete duplicate
+                            cmp = TreeNodeComparer.Default.Compare(nodes[0], nodes[1]);
+                            if (cmp == 0)
+                            {
+                                // If so, silently de-duplicate
+                                _nodes = new TreeNode[1] { nodes[0] };
+                                return;
+                            }
+
+                            // Else throw
                             throw CreateDuplicateException(nodes[0]);
+                        }
 
                         // Else sort & assign
-                        var cmp = TreeNodeComparer.Default.Compare(nodes[0], nodes[1]);
+                        cmp = TreeNodeComparer.Default.Compare(nodes[0], nodes[1]);
                         if (cmp < 0)
                             _nodes = new TreeNode[2] { nodes[0], nodes[1] };
                         else
@@ -104,7 +117,7 @@ namespace SourceCode.Chasm
                             if (!uniqueName.Add(array[i].Name))
                                 throw CreateDuplicateException(array[i]);
 
-                            // If it's empirically still sorted
+                            // If empirically, it's still sorted
                             if (sorted && i > 0)
                             {
                                 // Streaming assertion
@@ -161,12 +174,25 @@ namespace SourceCode.Chasm
                         enm.MoveNext();
                         var node1 = enm.Current;
 
-                        // Throw if the Name is duplicated
+                        // If the Name alone is duplicated
+                        int cmp;
                         if (StringComparer.Ordinal.Equals(node0.Name, node1.Name))
+                        {
+                            // Check if it's a complete duplicate
+                            cmp = TreeNodeComparer.Default.Compare(node0, node1);
+                            if (cmp == 0)
+                            {
+                                // If so, silently de-duplicate
+                                _nodes = new TreeNode[1] { node0 };
+                                return;
+                            }
+
+                            // Else throw
                             throw CreateDuplicateException(node0);
+                        }
 
                         // Else sort & assign
-                        var cmp = TreeNodeComparer.Default.Compare(node0, node1);
+                        cmp = TreeNodeComparer.Default.Compare(node0, node1);
                         if (cmp < 0)
                             _nodes = new TreeNode[2] { node0, node1 };
                         else
@@ -190,7 +216,7 @@ namespace SourceCode.Chasm
                             if (!uniqueName.Add(array[i].Name))
                                 throw CreateDuplicateException(array[i]);
 
-                            // If it's empirically still sorted
+                            // If empirically, it's still sorted
                             if (sorted && i > 0)
                             {
                                 // Streaming assertion

--- a/src/SourceCode.Chasm/TreeNodeList.cs
+++ b/src/SourceCode.Chasm/TreeNodeList.cs
@@ -275,7 +275,9 @@ namespace SourceCode.Chasm
             // Optimize for common cases 0, 1, 2, N
             switch (array.Length)
             {
-                case 1: return array;
+                case 1:
+                    // Always copy. The callsite may change the array after creating the TreeNodeList.
+                    return new TreeNode[1] { array[0] };
 
                 case 2:
                     {

--- a/src/SourceCode.Chasm/TreeNodeListComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeListComparer.cs
@@ -42,13 +42,7 @@ namespace SourceCode.Chasm
             { }
 
             public override bool Equals(TreeNodeList x, TreeNodeList y)
-            {
-                // Memory<T>.Span throws if IsEmpty == true
-                if (x._nodes.Length != y._nodes.Length) return false;
-                if (x._nodes.IsEmpty) return true;
-
-                return x._nodes.Span.SpanEquals(y._nodes.Span, true);
-            }
+                => x._nodes.MemoryEquals(y._nodes, true);
 
             public override int GetHashCode(TreeNodeList obj)
             {

--- a/src/SourceCode.Chasm/TreeNodeListComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeListComparer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using SourceCode.Clay.Collections.Generic;
 
 namespace SourceCode.Chasm
 {
@@ -42,17 +43,11 @@ namespace SourceCode.Chasm
 
             public override bool Equals(TreeNodeList x, TreeNodeList y)
             {
+                // Memory<T>.Span throws if IsEmpty == true
                 if (x._nodes.Length != y._nodes.Length) return false;
                 if (x._nodes.IsEmpty) return true;
 
-                var xspan = x._nodes.Span;
-                var yspan = y._nodes.Span;
-
-                for (var i = 0; i < xspan.Length; i++)
-                    if (xspan[i] != yspan[i])
-                        return false;
-
-                return true;
+                return x._nodes.Span.SpanEquals(y._nodes.Span, true);
             }
 
             public override int GetHashCode(TreeNodeList obj)

--- a/src/SourceCode.Chasm/TreeNodeListComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeListComparer.cs
@@ -1,5 +1,4 @@
-﻿using SourceCode.Clay.Collections.Generic;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace SourceCode.Chasm
 {
@@ -43,7 +42,15 @@ namespace SourceCode.Chasm
 
             public override bool Equals(TreeNodeList x, TreeNodeList y)
             {
-                if (!x._nodes.NullableEquals(y._nodes, true)) return false;
+                if (x._nodes.Length != y._nodes.Length) return false;
+                if (x._nodes.IsEmpty) return true;
+
+                var xspan = x._nodes.Span;
+                var yspan = y._nodes.Span;
+
+                for (var i = 0; i < xspan.Length; i++)
+                    if (xspan[i] != yspan[i])
+                        return false;
 
                 return true;
             }
@@ -54,7 +61,10 @@ namespace SourceCode.Chasm
 
                 unchecked
                 {
-                    h = h * 7 + (obj._nodes?.Length ?? 42);
+                    h = h * 7 + obj._nodes.Length;
+
+                    if (obj._nodes.Length > 0)
+                        h = h * 7 + obj._nodes.Span[0].GetHashCode();
                 }
 
                 return h;


### PR DESCRIPTION
- Align with latest Nuget
- Change `TreeNodeList._nodes` from `TreeNode[]` to `ReadOnlyMemory<TreeNode>`
- Optimize distinct sort in `TreeNodeList.ctor`
- Fixes #18 Merge Optimizations
- Fix unit names, commenting, CodeMaid, etc