### PR TITLE
Add methods for serializing CommitRef to IChasmSerializer

### DIFF
--- a/src/SourceCode.Chasm.Repository.AzureBlob/AzureBlobChasmRepo.Tree.cs
+++ b/src/SourceCode.Chasm.Repository.AzureBlob/AzureBlobChasmRepo.Tree.cs
@@ -68,11 +68,11 @@ namespace SourceCode.Chasm.IO.AzureBlob
             if (string.IsNullOrWhiteSpace(commitRefName)) throw new ArgumentNullException(nameof(commitRefName));
 
             // CommitRef
-            var commitId = await ReadCommitRefAsync(branch, commitRefName, cancellationToken).ConfigureAwait(false);
-            if (commitId == CommitId.Empty) return default;
+            var commitRef = await ReadCommitRefAsync(branch, commitRefName, cancellationToken).ConfigureAwait(false);
+            if (commitRef == CommitRef.Empty) return default;
 
             // Tree
-            var tree = await ReadTreeAsync(commitId, cancellationToken).ConfigureAwait(false);
+            var tree = await ReadTreeAsync(commitRef.CommitId, cancellationToken).ConfigureAwait(false);
             return tree;
         }
 

--- a/src/SourceCode.Chasm.Repository.AzureBlob/SourceCode.Chasm.Repository.AzureBlob.csproj
+++ b/src/SourceCode.Chasm.Repository.AzureBlob/SourceCode.Chasm.Repository.AzureBlob.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00202" />
+    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00205" />
     <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00202" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.4.0" />
   </ItemGroup>

--- a/src/SourceCode.Chasm.Repository.AzureTable/AzureTableChasmRepo.Tree.cs
+++ b/src/SourceCode.Chasm.Repository.AzureTable/AzureTableChasmRepo.Tree.cs
@@ -68,11 +68,11 @@ namespace SourceCode.Chasm.IO.AzureTable
             if (string.IsNullOrWhiteSpace(commitRefName)) throw new ArgumentNullException(nameof(commitRefName));
 
             // CommitRef
-            var commitId = await ReadCommitRefAsync(branch, commitRefName, cancellationToken).ConfigureAwait(false);
-            if (commitId == CommitId.Empty) return default;
+            var commitRef = await ReadCommitRefAsync(branch, commitRefName, cancellationToken).ConfigureAwait(false);
+            if (commitRef == CommitRef.Empty) return default;
 
             // Tree
-            var tree = await ReadTreeAsync(commitId, cancellationToken).ConfigureAwait(false);
+            var tree = await ReadTreeAsync(commitRef.CommitId, cancellationToken).ConfigureAwait(false);
             return tree;
         }
 

--- a/src/SourceCode.Chasm.Repository.AzureTable/SourceCode.Chasm.Repository.AzureTable.csproj
+++ b/src/SourceCode.Chasm.Repository.AzureTable/SourceCode.Chasm.Repository.AzureTable.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00202" />
+    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00205" />
     <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00202" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.4.0" />
   </ItemGroup>

--- a/src/SourceCode.Chasm.Repository.Disk/DiskChasmRepo.CommitRef.cs
+++ b/src/SourceCode.Chasm.Repository.Disk/DiskChasmRepo.CommitRef.cs
@@ -16,7 +16,7 @@ namespace SourceCode.Chasm.IO.Disk
     {
         #region Read
 
-        public async ValueTask<CommitId> ReadCommitRefAsync(string branch, string name, CancellationToken cancellationToken)
+        public async ValueTask<CommitRef> ReadCommitRefAsync(string branch, string name, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(branch)) throw new ArgumentNullException(nameof(branch));
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name));
@@ -26,17 +26,15 @@ namespace SourceCode.Chasm.IO.Disk
 
             var bytes = await ReadFileAsync(path, cancellationToken).ConfigureAwait(false);
 
-            var sha1 = Serializer.DeserializeSha1(bytes);
-
-            var commitId = new CommitId(sha1);
-            return commitId;
+            var commitRef = Serializer.DeserializeCommitRef(bytes);
+            return commitRef;
         }
 
         #endregion
 
         #region Write
 
-        public async Task WriteCommitRefAsync(CommitId? previousCommitId, string branch, string name, CommitId newCommitId, CancellationToken cancellationToken)
+        public async Task WriteCommitRefAsync(CommitId? previousCommitId, string branch, string name, CommitRef commitRef, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(branch)) throw new ArgumentNullException(nameof(branch));
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name));
@@ -46,7 +44,7 @@ namespace SourceCode.Chasm.IO.Disk
             var filename = DeriveCommitRefFileName(branch, name);
             var path = Path.Combine(_refsContainer, filename);
 
-            using (var session = Serializer.Serialize(newCommitId.Sha1))
+            using (var session = Serializer.Serialize(commitRef))
             {
                 await WriteFileAsync(path, session.Result, cancellationToken).ConfigureAwait(false);
             }

--- a/src/SourceCode.Chasm.Repository.Disk/DiskChasmRepo.Object.cs
+++ b/src/SourceCode.Chasm.Repository.Disk/DiskChasmRepo.Object.cs
@@ -34,6 +34,8 @@ namespace SourceCode.Chasm.IO.Disk
             var path = Path.Combine(_objectsContainer, filename);
 
             var bytes = await ReadFileAsync(path, cancellationToken).ConfigureAwait(false);
+            if (bytes == null)
+                return default;
 
             using (var input = new MemoryStream(bytes.ToArray())) // TODO: Perf
             using (var gzip = new GZipStream(input, CompressionMode.Decompress, false))

--- a/src/SourceCode.Chasm.Repository.Disk/DiskChasmRepo.Tree.cs
+++ b/src/SourceCode.Chasm.Repository.Disk/DiskChasmRepo.Tree.cs
@@ -68,11 +68,11 @@ namespace SourceCode.Chasm.IO.Disk
             if (string.IsNullOrWhiteSpace(commitRefName)) throw new ArgumentNullException(nameof(commitRefName));
 
             // CommitRef
-            var commitId = await ReadCommitRefAsync(branch, commitRefName, cancellationToken).ConfigureAwait(false);
-            if (commitId == CommitId.Empty) return default;
+            var commitRef = await ReadCommitRefAsync(branch, commitRefName, cancellationToken).ConfigureAwait(false);
+            if (commitRef == CommitRef.Empty) return default;
 
             // Tree
-            var tree = await ReadTreeAsync(commitId, cancellationToken).ConfigureAwait(false);
+            var tree = await ReadTreeAsync(commitRef.CommitId, cancellationToken).ConfigureAwait(false);
             return tree;
         }
 

--- a/src/SourceCode.Chasm.Repository.Disk/SourceCode.Chasm.Repository.Disk.csproj
+++ b/src/SourceCode.Chasm.Repository.Disk/SourceCode.Chasm.Repository.Disk.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00202" />
+    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00205" />
     <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00202" />
   </ItemGroup>
 

--- a/src/SourceCode.Chasm.Repository.Tests/ChasmRepositoryTests.cs
+++ b/src/SourceCode.Chasm.Repository.Tests/ChasmRepositoryTests.cs
@@ -36,12 +36,12 @@ namespace SourceCode.Chasm.IO.Azure.Tests
             repo.Setup(r => r.CompressionLevel).Returns(System.IO.Compression.CompressionLevel.NoCompression);
             repo.Setup(r => r.MaxDop).Returns(-1);
 
-            repo.Setup(r => r.ReadCommitRefAsync(null, null, CancellationToken.None)).Returns(new ValueTask<CommitId>(CommitId.Empty));
-            repo.Setup(r => r.ReadCommitRefAsync(string.Empty, null, CancellationToken.None)).Returns(new ValueTask<CommitId>(CommitId.Empty));
-            repo.Setup(r => r.ReadCommitRefAsync(null, string.Empty, CancellationToken.None)).Returns(new ValueTask<CommitId>(CommitId.Empty));
-            repo.Setup(r => r.ReadCommitRefAsync(string.Empty, string.Empty, CancellationToken.None)).Returns(new ValueTask<CommitId>(CommitId.Empty));
+            repo.Setup(r => r.ReadCommitRefAsync(null, null, CancellationToken.None)).Returns(new ValueTask<CommitRef>(CommitRef.Empty));
+            repo.Setup(r => r.ReadCommitRefAsync(string.Empty, null, CancellationToken.None)).Returns(new ValueTask<CommitRef>(CommitRef.Empty));
+            repo.Setup(r => r.ReadCommitRefAsync(null, string.Empty, CancellationToken.None)).Returns(new ValueTask<CommitRef>(CommitRef.Empty));
+            repo.Setup(r => r.ReadCommitRefAsync(string.Empty, string.Empty, CancellationToken.None)).Returns(new ValueTask<CommitRef>(CommitRef.Empty));
 
-            repo.Setup(r => r.ReadCommitRefAsync("branch", "name", CancellationToken.None)).Returns(new ValueTask<CommitId>(new CommitId(Sha1.Hash("branch-name"))));
+            repo.Setup(r => r.ReadCommitRefAsync("branch", "name", CancellationToken.None)).Returns(new ValueTask<CommitRef>(new CommitRef(new CommitId(Sha1.Hash("branch-name")))));
         }
 
         #endregion

--- a/src/SourceCode.Chasm.Serializer.Json/JsonChasmSerializer.CommitRef.cs
+++ b/src/SourceCode.Chasm.Serializer.Json/JsonChasmSerializer.CommitRef.cs
@@ -1,0 +1,56 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Chasm.IO.Json.Wire;
+using SourceCode.Clay.Buffers;
+using System;
+using System.Text;
+
+namespace SourceCode.Chasm.IO.Json
+{
+    partial class JsonChasmSerializer // .CommitRef
+    {
+        #region Serialize
+
+        public BufferSession Serialize(CommitRef model)
+        {
+            var wire = model.Convert();
+            var json = wire?.ToString() ?? "null";
+
+            var maxLen = Encoding.UTF8.GetMaxByteCount(json.Length); // Utf8 is 1-4 bpc
+            var rented = BufferSession.RentBuffer(maxLen);
+            var count = Encoding.UTF8.GetBytes(json, 0, json.Length, rented, 0);
+
+            var seg = new ArraySegment<byte>(rented, 0, count);
+            var session = new BufferSession(seg);
+            return session;
+        }
+
+        #endregion
+
+        #region Deserialize
+
+        public CommitRef DeserializeCommitRef(ReadOnlySpan<byte> span)
+        {
+            if (span.IsEmpty) throw new ArgumentNullException(nameof(span));
+
+            string json;
+            unsafe
+            {
+                fixed (byte* ptr = &span.DangerousGetPinnableReference())
+                {
+                    json = Encoding.UTF8.GetString(ptr, span.Length);
+                }
+            }
+
+            var model = json.ParseCommitRef();
+            return model;
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Serializer.Json/SourceCode.Chasm.Serializer.Json.csproj
+++ b/src/SourceCode.Chasm.Serializer.Json/SourceCode.Chasm.Serializer.Json.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00202" />
+    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00205" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm.Serializer.Json/Wire/CommitRefWireExtensions.cs
+++ b/src/SourceCode.Chasm.Serializer.Json/Wire/CommitRefWireExtensions.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Chasm.IO.Json.Wire
 {
     internal static class CommitRefWireExtensions
     {
-        #region Fields
+        #region Constants
 
         private const string _sha1 = "sha1";
 
@@ -22,7 +22,7 @@ namespace SourceCode.Chasm.IO.Json.Wire
 
         public static JsonObject Convert(this CommitRef model)
         {
-            if (model == CommitRef.Empty) return default;
+            if (model == CommitRef.Empty) return default; // null
 
             var wire = new JsonObject
             {

--- a/src/SourceCode.Chasm.Serializer.Json/Wire/CommitWireExtensions.cs
+++ b/src/SourceCode.Chasm.Serializer.Json/Wire/CommitWireExtensions.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Chasm.IO.Json.Wire
 {
     internal static class CommitWireExtensions
     {
-        #region Fields
+        #region Constants
 
         private const string _parents = "parents";
         private const string _treeId = "treeId";

--- a/src/SourceCode.Chasm.Serializer.Proto/ProtoChasmSerializer.CommitRef.cs
+++ b/src/SourceCode.Chasm.Serializer.Proto/ProtoChasmSerializer.CommitRef.cs
@@ -1,0 +1,54 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using Google.Protobuf;
+using SourceCode.Chasm.IO.Proto.Wire;
+using SourceCode.Clay.Buffers;
+using System;
+
+namespace SourceCode.Chasm.IO.Proto
+{
+    partial class ProtoChasmSerializer // .CommitRef
+    {
+        #region Serialize
+
+        public BufferSession Serialize(CommitRef model)
+        {
+            var wire = model.Convert();
+
+            var size = wire.CalculateSize();
+            var buffer = BufferSession.RentBuffer(size);
+
+            using (var cos = new CodedOutputStream(buffer))
+            {
+                wire.WriteTo(cos);
+
+                var segment = new ArraySegment<byte>(buffer, 0, (int)cos.Position);
+
+                var session = new BufferSession(buffer, segment);
+                return session;
+            }
+        }
+
+        #endregion
+
+        #region Deserialize
+
+        public CommitRef DeserializeCommitRef(ReadOnlySpan<byte> span)
+        {
+            if (span.IsEmpty) return default;
+
+            var wire = new CommitRefWire();
+            wire.MergeFrom(span.ToArray()); // TODO: Perf
+
+            var model = wire.Convert();
+            return model;
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Serializer.Proto/Wire/CommitRefWireExtensions.cs
+++ b/src/SourceCode.Chasm.Serializer.Proto/Wire/CommitRefWireExtensions.cs
@@ -13,7 +13,7 @@ namespace SourceCode.Chasm.IO.Proto.Wire
 
         public static CommitRefWire Convert(this CommitRef model)
         {
-            if (model == CommitRef.Empty) return default;
+            if (model == CommitRef.Empty) return new CommitRefWire();
 
             var wire = new CommitRefWire
             {

--- a/src/SourceCode.Chasm.Serializer.Tests/CommitRefTests.cs
+++ b/src/SourceCode.Chasm.Serializer.Tests/CommitRefTests.cs
@@ -9,32 +9,32 @@ using Xunit;
 
 namespace SourceCode.Chasm.IO.Tests
 {
-    public static class Sha1Tests
+    public static partial class CommitRefTests
     {
         #region Methods
 
         [Trait("Type", "Unit")]
-        [Theory(DisplayName = nameof(ChasmSerializer_Roundtrip_Sha1_Empty))]
+        [Theory(DisplayName = nameof(ChasmSerializer_Roundtrip_CommitRef_Default))]
         [ClassData(typeof(TestData))]
-        public static void ChasmSerializer_Roundtrip_Sha1_Empty(IChasmSerializer ser)
+        public static void ChasmSerializer_Roundtrip_CommitRef_Default(IChasmSerializer ser)
         {
-            var expected = Sha1.Empty;
+            var expected = CommitRef.Empty;
             using (var buf = ser.Serialize(expected))
             {
-                var actual = ser.DeserializeSha1(buf.Result);
+                var actual = ser.DeserializeCommitRef(buf.Result);
                 Assert.Equal(expected, actual);
             }
         }
 
         [Trait("Type", "Unit")]
-        [Theory(DisplayName = nameof(ChasmSerializer_Roundtrip_Sha1))]
+        [Theory(DisplayName = nameof(ChasmSerializer_Roundtrip_CommitRef_CommitId))]
         [ClassData(typeof(TestData))]
-        public static void ChasmSerializer_Roundtrip_Sha1(IChasmSerializer ser)
+        public static void ChasmSerializer_Roundtrip_CommitRef_CommitId(IChasmSerializer ser)
         {
-            var expected = Sha1.Hash("abc");
+            var expected = new CommitRef(new CommitId(Sha1.Hash("abc")));
             using (var buf = ser.Serialize(expected))
             {
-                var actual = ser.DeserializeSha1(buf.Result);
+                var actual = ser.DeserializeCommitRef(buf.Result);
                 Assert.Equal(expected, actual);
             }
         }

--- a/src/SourceCode.Chasm.Serializer.Tests/CommitTests.cs
+++ b/src/SourceCode.Chasm.Serializer.Tests/CommitTests.cs
@@ -5,6 +5,7 @@
 
 #endregion
 
+using System;
 using Xunit;
 
 namespace SourceCode.Chasm.IO.Tests
@@ -18,8 +19,7 @@ namespace SourceCode.Chasm.IO.Tests
         [ClassData(typeof(TestData))]
         public static void ChasmSerializer_Roundtrip_Commit_Default(IChasmSerializer ser)
         {
-            // All default
-            var expected = new Commit(null, default, default, null);
+            var expected = Commit.Empty;
             using (var buf = ser.Serialize(expected))
             {
                 var actual = ser.DeserializeCommit(buf.Result);

--- a/src/SourceCode.Chasm.Serializer.Tests/TreeNodeListTests.cs
+++ b/src/SourceCode.Chasm.Serializer.Tests/TreeNodeListTests.cs
@@ -11,7 +11,7 @@ namespace SourceCode.Chasm.IO.Tests
 {
     public static class TreeNodeListTests
     {
-        #region Fields
+        #region Constants
 
         private static readonly TreeNode Node1 = new TreeNode(nameof(Node1), new BlobId(Sha1.Hash(nameof(Node1))));
         private static readonly TreeNode Node2 = new TreeNode(nameof(Node2), new BlobId(Sha1.Hash(nameof(Node2))));

--- a/src/SourceCode.Chasm.Tests/TreeNodeListTests.cs
+++ b/src/SourceCode.Chasm.Tests/TreeNodeListTests.cs
@@ -332,14 +332,6 @@ namespace SourceCode.Chasm.Tests
                 new TreeNode("r", NodeKind.Blob, Sha1.Hash("Test9")),
             };
 
-            var dupes = new[]
-            {
-                new TreeNode(list2[0].Name, list2[0].Kind, list2[1].Sha1),
-                new TreeNode(list2[1].Name, list2[1].Kind, list2[2].Sha1),
-                new TreeNode(list2[2].Name, list2[2].Kind, list2[3].Sha1),
-                new TreeNode(list2[3].Name, list2[3].Kind, list2[0].Sha1)
-            };
-
             var list3 = list1.Merge(list2);
 
             Assert.Equal(9, list3.Count);
@@ -364,7 +356,15 @@ namespace SourceCode.Chasm.Tests
             Assert.Equal(list2[5].Sha1, list3[7].Sha1);
             Assert.Equal(list2[6].Sha1, list3[8].Sha1);
 
-            //Assert.Throws<ArgumentException>(() => list3.Merge(dupes));
+            var dupes = new[]
+            {
+                new TreeNode(list2[0].Name, list2[0].Kind, list2[1].Sha1),
+                new TreeNode(list2[1].Name, list2[1].Kind, list2[2].Sha1),
+                new TreeNode(list2[2].Name, list2[2].Kind, list2[3].Sha1),
+                new TreeNode(list2[3].Name, list2[3].Kind, list2[0].Sha1)
+            };
+
+            list3 = list3.Merge(dupes);
         }
 
         #endregion

--- a/src/SourceCode.Chasm/CommitRef.cs
+++ b/src/SourceCode.Chasm/CommitRef.cs
@@ -33,8 +33,6 @@ namespace SourceCode.Chasm
 
         public CommitRef(CommitId commitId)
         {
-            if (commitId == CommitId.Empty) throw new ArgumentNullException(nameof(commitId));
-
             CommitId = commitId;
         }
 

--- a/src/SourceCode.Chasm/IO/IChasmRepository.CommitRef.cs
+++ b/src/SourceCode.Chasm/IO/IChasmRepository.CommitRef.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Chasm.IO
     {
         #region Methods
 
-        ValueTask<CommitId> ReadCommitRefAsync(string branch, string name, CancellationToken cancellationToken);
+        ValueTask<CommitRef> ReadCommitRefAsync(string branch, string name, CancellationToken cancellationToken);
 
         /// <summary>
         /// Write a <see cref="CommitRef"/> to the repository using the provided values.
@@ -23,11 +23,11 @@ namespace SourceCode.Chasm.IO
         /// <param name="branch">The repository name.</param>
         /// <param name="name">The name of the <see cref="CommitRef"/></param>
         /// <param name="previousCommitId">The previous <see cref="CommitId"/> that the caller used for reading.</param>
-        /// <param name="newCommitId">The new <see cref="CommitId"/> that represents the content being written.</param>
+        /// <param name="commitRef">The new <see cref="CommitRef"/> that represents the content being written.</param>
         /// <param name="cancellationToken">Allows the <see cref="Task"/> to be cancelled.</param>
         /// <exception cref="ChasmConcurrencyException">Thrown when a concurrency exception is detected.</exception>
         /// <returns></returns>
-        Task WriteCommitRefAsync(CommitId? previousCommitId, string branch, string name, CommitId newCommitId, CancellationToken cancellationToken);
+        Task WriteCommitRefAsync(CommitId? previousCommitId, string branch, string name, CommitRef commitRef, CancellationToken cancellationToken);
 
         #endregion
     }

--- a/src/SourceCode.Chasm/IO/IChasmSerializer.CommitRef.cs
+++ b/src/SourceCode.Chasm/IO/IChasmSerializer.CommitRef.cs
@@ -1,0 +1,23 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Buffers;
+using System;
+
+namespace SourceCode.Chasm.IO
+{
+    partial interface IChasmSerializer // .CommitRef
+    {
+        #region Methods
+
+        BufferSession Serialize(CommitRef model);
+
+        CommitRef DeserializeCommitRef(ReadOnlySpan<byte> span);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm/Sha1.cs
+++ b/src/SourceCode.Chasm/Sha1.cs
@@ -121,8 +121,7 @@ namespace SourceCode.Chasm
         [SecuritySafeCritical]
         public Sha1(byte[] buffer, int offset)
         {
-            if (buffer == null)
-                throw new ArgumentNullException(nameof(buffer));
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
 
             if (buffer.Length < ByteLen)
                 throw new ArgumentOutOfRangeException(nameof(buffer), $"{nameof(buffer)} must have length at least {ByteLen}");
@@ -441,7 +440,7 @@ namespace SourceCode.Chasm
             if (prefixLength <= 0)
                 return new KeyValuePair<string, string>(string.Empty, new string(chars));
 
-            if (prefixLength > CharLen)
+            if (prefixLength >= CharLen)
                 return new KeyValuePair<string, string>(new string(chars), string.Empty);
 
             var key = new string(chars, 0, prefixLength);

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.4.1.3596">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00202" />
-    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00202" />
+    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00205" />
+    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00205" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Fixes #67 - Add methods for serializing `CommitRef` to `IChasmSerializer`
- Align the corresponding methods in `IChasmRepository`