### PR TITLE
Add CodeFactor badge and .NET core prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Rather, this is meant to be a general purpose CAS store for any document type.
 * Efficient network/disk operations: XML is bad, JSON is better, Protobuf/etc are best
 * Simple: Avoid the need to reinvent graph semantics, etc
 
+### Prerequisites
+
+* .NET Core SDK 2.0 (https://www.microsoft.com/net/download/core)
+
 ### Getting started
 
 **Getting started with Git and GitHub**

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build status](https://ci.appveyor.com/api/projects/status/993h43mvva8iqb7u/branch/master?svg=true)](https://ci.appveyor.com/project/jcdickinson/chasm/branch/master)
 [![Code Coverage](https://codecov.io/gh/k2workflow/Chasm/coverage.svg)](https://codecov.io/gh/k2workflow/Chasm)
+[![CodeFactor](https://www.codefactor.io/repository/github/jannesrsa/chasm/badge)](https://www.codefactor.io/repository/github/jannesrsa/chasm)
 
 ### CAS = Content Addressable Storage
 


### PR DESCRIPTION
I've added one more badge, the CodeFactor badge pointing to https://www.codefactor.io.
I found it useful for spotting duplicate code. You would have to change the URL, but you can have a look at my branch's for an idea of what it does.

https://www.codefactor.io/repository/github/jannesrsa/chasm

Also added a Prerequisites section to the README.