### PR TITLE
Fix File Workaround in Disk Repo

### DIFF
--- a/src/SourceCode.Chasm.Repository.Disk/SourceCode.Chasm.Repository.Disk.csproj
+++ b/src/SourceCode.Chasm.Repository.Disk/SourceCode.Chasm.Repository.Disk.csproj
@@ -27,5 +27,6 @@
     <PackageTags>cas content storage sha1 git disk file</PackageTags>
     <Version>1.0.0-local</Version>
     <PackageVersion>1.0.0-local</PackageVersion>
+    <RootNamespace>SourceCode.Chasm.IO.Disk</RootNamespace>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Waiting for an unlocked file will always be required. It is now async and throws correctly. The concurrency model for CommitRef is now implemented.

- Cleaning up uneeded checks in the DiskChasmRepo ctor.
- ReadObjectBatchAsync is now parallel.

Fixes #71
Fixes #95.