### PR TITLE
Unit Tests to get SourceCode.Chasm to 100% code coverage

### DIFF
--- a/src/SourceCode.Chasm.Tests/AuditTests.cs
+++ b/src/SourceCode.Chasm.Tests/AuditTests.cs
@@ -6,6 +6,8 @@
 #endregion
 
 using System;
+using SourceCode.Chasm.Tests.Helpers;
+using SourceCode.Chasm.Tests.TestObjects;
 using Xunit;
 
 namespace SourceCode.Chasm.Tests
@@ -19,8 +21,8 @@ namespace SourceCode.Chasm.Tests
         public static void Audit_Deconstruct()
         {
             // Arrange
-            var expectedName = Guid.NewGuid().ToString();
-            var expectedDateTimeOffset = DateTimeOffset.MaxValue;
+            var expectedName = RandomHelper.String;
+            var expectedDateTimeOffset = RandomHelper.DateTimeOffset;
             var audit = new Audit(expectedName, expectedDateTimeOffset);
 
             // Action
@@ -32,13 +34,11 @@ namespace SourceCode.Chasm.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(Audit_Deconstruct))]
+        [Fact(DisplayName = nameof(Audit_Equals_Object))]
         public static void Audit_Equals_Object()
         {
             // Arrange
-            var expectedName = Guid.NewGuid().ToString();
-            var expectedDateTimeOffset = DateTimeOffset.MaxValue;
-            var audit = new Audit(expectedName, expectedDateTimeOffset);
+            var audit = AuditTestObject.Random;
 
             // Action
             Assert.True(audit.Equals((object)audit));

--- a/src/SourceCode.Chasm.Tests/AuditTests.cs
+++ b/src/SourceCode.Chasm.Tests/AuditTests.cs
@@ -1,0 +1,50 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using Xunit;
+
+namespace SourceCode.Chasm.Tests
+{
+    public static class AuditTests
+    {
+        #region Methods
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(Audit_Deconstruct))]
+        public static void Audit_Deconstruct()
+        {
+            // Arrange
+            var expectedName = Guid.NewGuid().ToString();
+            var expectedDateTimeOffset = DateTimeOffset.MaxValue;
+            var audit = new Audit(expectedName, expectedDateTimeOffset);
+
+            // Action
+            audit.Deconstruct(out var actualName, out var actualDateTimeOffset);
+
+            // Assert
+            Assert.Equal(expectedName, actualName);
+            Assert.Equal(expectedDateTimeOffset, actualDateTimeOffset);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(Audit_Deconstruct))]
+        public static void Audit_Equals_Object()
+        {
+            // Arrange
+            var expectedName = Guid.NewGuid().ToString();
+            var expectedDateTimeOffset = DateTimeOffset.MaxValue;
+            var audit = new Audit(expectedName, expectedDateTimeOffset);
+
+            // Action
+            Assert.True(audit.Equals((object)audit));
+            Assert.False(audit.Equals(new object()));
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/Helpers/RandomHelper.cs
+++ b/src/SourceCode.Chasm.Tests/Helpers/RandomHelper.cs
@@ -1,0 +1,36 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Chasm.Tests.Helpers
+{
+    public static class RandomHelper
+    {
+        #region Properties
+
+        public static byte[] ByteArray
+        {
+            get
+            {
+                var buffer = new byte[Random.Next()];
+                Random.NextBytes(buffer);
+                return buffer;
+            }
+        }
+
+        public static Random Random => new Random(Guid.NewGuid().GetHashCode());
+
+        public static string String => Guid.NewGuid().ToString("n");
+
+        public static DateTime DateTime => DateTime.Now.Subtract(new TimeSpan(Random.Next(3650), Random.Next(12), Random.Next(59), Random.Next(59)));
+
+        public static DateTimeOffset DateTimeOffset => new DateTimeOffset(DateTime);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/IO/ChasmConcurrencyExceptionTests.cs
+++ b/src/SourceCode.Chasm.Tests/IO/ChasmConcurrencyExceptionTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Runtime.Serialization;
 using Moq;
 using SourceCode.Chasm.IO;
+using SourceCode.Chasm.Tests.Helpers;
 using Xunit;
 
 namespace SourceCode.Chasm.Tests.IO
@@ -33,7 +34,7 @@ namespace SourceCode.Chasm.Tests.IO
         public static void ChasmConcurrencyException_Constructor_String()
         {
             // Arrange
-            var expectedMessage = Guid.NewGuid().ToString();
+            var expectedMessage = RandomHelper.String;
 
             // Action
             var actual = new ChasmConcurrencyException(expectedMessage);
@@ -48,8 +49,8 @@ namespace SourceCode.Chasm.Tests.IO
         public static void ChasmConcurrencyException_Constructor_String_Exception()
         {
             // Arrange
-            var expectedInnerException = new Exception(Guid.NewGuid().ToString());
-            var expectedMessage = Guid.NewGuid().ToString();
+            var expectedInnerException = new Exception(RandomHelper.String);
+            var expectedMessage = RandomHelper.String;
 
             // Action
             var actual = new ChasmConcurrencyException(expectedMessage, expectedInnerException);

--- a/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTests.cs
+++ b/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTests.cs
@@ -19,6 +19,25 @@ namespace SourceCode.Chasm.Tests.IO
         #region Methods
 
         [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepository_BuildConcurrencyException))]
+        public static void ChasmRepository_BuildConcurrencyException()
+        {
+            // Arrange
+            var expectedBranch = Guid.NewGuid().ToString();
+            var expectedName = Guid.NewGuid().ToString();
+            var expectedInnerException = new Exception(Guid.NewGuid().ToString());
+
+            // Action
+            var actual = MockChasmRepository.MockBuildConcurrencyException(expectedBranch, expectedName, expectedInnerException);
+
+            // Assert
+            Assert.Equal(expectedInnerException, actual.InnerException);
+            Assert.Contains(nameof(CommitRef), actual.Message);
+            Assert.Contains(expectedBranch, actual.Message);
+            Assert.Contains(expectedName, actual.Message);
+        }
+
+        [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(ChasmRepository_Constructor_ChasmSerializer_CompressionLevel_MaxDop))]
         public static void ChasmRepository_Constructor_ChasmSerializer_CompressionLevel_MaxDop()
         {
@@ -36,6 +55,33 @@ namespace SourceCode.Chasm.Tests.IO
             Assert.Equal(mockChasmSerializer.Object, actual.Serializer);
             Assert.Equal(expectedCompressionLevel, actual.CompressionLevel);
             Assert.Equal(expectedMaxDop, actual.MaxDop);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepository_Constructor_OutOfRange_CompressionLevel))]
+        public static void ChasmRepository_Constructor_OutOfRange_CompressionLevel()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var expectedCompressionLevel = (CompressionLevel)int.MaxValue;
+            var expectedMaxDop = default(int);
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, expectedCompressionLevel, expectedMaxDop);
+
+            // Action
+            var actual = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                try
+                {
+                    var obj = mockChasmRepository.Object;
+                }
+                catch (TargetInvocationException targetInvocationException)
+                {
+                    throw targetInvocationException.InnerException;
+                }
+            });
+
+            // Assert
+            Assert.Contains("compressionLevel", actual.Message);
         }
 
         [Trait("Type", "Unit")]
@@ -93,17 +139,17 @@ namespace SourceCode.Chasm.Tests.IO
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(ChasmRepository_Constructor_OutOfRange_CompressionLevel))]
-        public static void ChasmRepository_Constructor_OutOfRange_CompressionLevel()
+        [Fact(DisplayName = nameof(ChasmRepository_Constructor_ChasmSerializer_CompressionLevel_MaxDop))]
+        public static void ChasmRepository_Constructor_SerialzerNull()
         {
             // Arrange
-            var mockChasmSerializer = new Mock<IChasmSerializer>();
-            var expectedCompressionLevel = (CompressionLevel)int.MaxValue;
-            var expectedMaxDop = default(int);
-            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, expectedCompressionLevel, expectedMaxDop);
+            var chasmSerializer = default(IChasmSerializer);
+            var expectedCompressionLevel = CompressionLevel.NoCompression;
+            var expectedMaxDop = 5;
+            var mockChasmRepository = new Mock<ChasmRepository>(chasmSerializer, expectedCompressionLevel, expectedMaxDop);
 
             // Action
-            var actual = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            var actual = Assert.Throws<ArgumentNullException>(() =>
             {
                 try
                 {
@@ -116,26 +162,7 @@ namespace SourceCode.Chasm.Tests.IO
             });
 
             // Assert
-            Assert.Contains("compressionLevel", actual.Message);
-        }
-
-        [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(ChasmRepository_BuildConcurrencyException))]
-        public static void ChasmRepository_BuildConcurrencyException()
-        {
-            // Arrange
-            var expectedBranch = Guid.NewGuid().ToString();
-            var expectedName = Guid.NewGuid().ToString();
-            var expectedInnerException = new Exception(Guid.NewGuid().ToString());
-
-            // Action
-            var actual = MockChasmRepository.MockBuildConcurrencyException(expectedBranch, expectedName, expectedInnerException);
-
-            // Assert
-            Assert.Equal(expectedInnerException, actual.InnerException);
-            Assert.Contains(nameof(CommitRef), actual.Message);
-            Assert.Contains(expectedBranch, actual.Message);
-            Assert.Contains(expectedName, actual.Message);
+            Assert.Contains("serializer", actual.Message);
         }
 
         #endregion

--- a/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTests.cs
+++ b/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTests.cs
@@ -10,6 +10,7 @@ using System.IO.Compression;
 using System.Reflection;
 using Moq;
 using SourceCode.Chasm.IO;
+using SourceCode.Chasm.Tests.Helpers;
 using Xunit;
 
 namespace SourceCode.Chasm.Tests.IO
@@ -23,9 +24,9 @@ namespace SourceCode.Chasm.Tests.IO
         public static void ChasmRepository_BuildConcurrencyException()
         {
             // Arrange
-            var expectedBranch = Guid.NewGuid().ToString();
-            var expectedName = Guid.NewGuid().ToString();
-            var expectedInnerException = new Exception(Guid.NewGuid().ToString());
+            var expectedBranch = RandomHelper.String;
+            var expectedName = RandomHelper.String;
+            var expectedInnerException = new Exception(RandomHelper.String);
 
             // Action
             var actual = MockChasmRepository.MockBuildConcurrencyException(expectedBranch, expectedName, expectedInnerException);

--- a/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTreeTests.cs
+++ b/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTreeTests.cs
@@ -14,6 +14,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using SourceCode.Chasm.IO;
+using SourceCode.Chasm.Tests.Helpers;
+using SourceCode.Chasm.Tests.TestObjects;
 using SourceCode.Clay.Collections.Generic;
 using Xunit;
 
@@ -29,7 +31,7 @@ namespace SourceCode.Chasm.Tests.IO
         {
             // Arrange
             var mockChasmSerializer = new Mock<IChasmSerializer>();
-            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(TestValues.Commit);
+            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(CommitTestObject.Random);
             var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
             {
                 CallBase = true
@@ -39,11 +41,11 @@ namespace SourceCode.Chasm.Tests.IO
                 .Returns(async () =>
                 {
                     await Task.Yield();
-                    return TestValues.CommitRef;
+                    return CommitRefTestObject.Random;
                 });
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.Branch, TestValues.CommitRef.Name, TestValues.CancellationToken);
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(RandomHelper.String, CommitRefTestObject.Random.Name, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -61,7 +63,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = Assert.ThrowsAsync<ArgumentNullException>(async () => await mockChasmRepository.Object.ReadTreeAsync(TestValues.Branch, default, TestValues.CancellationToken));
+            var actual = Assert.ThrowsAsync<ArgumentNullException>(async () => await mockChasmRepository.Object.ReadTreeAsync(RandomHelper.String, default, TestValues.CancellationToken));
 
             // Assert
             Assert.Contains("commitRefName", actual.Result.Message);
@@ -79,7 +81,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.Branch, TestValues.CommitRef.Name, TestValues.CancellationToken);
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(RandomHelper.String, CommitRefTestObject.Random.Name, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -97,7 +99,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = Assert.ThrowsAsync<ArgumentNullException>(async () => await mockChasmRepository.Object.ReadTreeAsync(default, TestValues.CommitRef.Name, TestValues.CancellationToken));
+            var actual = Assert.ThrowsAsync<ArgumentNullException>(async () => await mockChasmRepository.Object.ReadTreeAsync(default, CommitRefTestObject.Random.Name, TestValues.CancellationToken));
 
             // Assert
             Assert.Contains("branch", actual.Result.Message);
@@ -109,7 +111,7 @@ namespace SourceCode.Chasm.Tests.IO
         {
             // Arrange
             var mockChasmSerializer = new Mock<IChasmSerializer>();
-            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(TestValues.Commit);
+            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(CommitTestObject.Random);
             var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
             {
                 CallBase = true
@@ -123,7 +125,7 @@ namespace SourceCode.Chasm.Tests.IO
                 });
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.CommitId, TestValues.CancellationToken);
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(CommitIdTestObject.Random, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -159,7 +161,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.CommitId, TestValues.CancellationToken);
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(CommitIdTestObject.Random, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -171,7 +173,7 @@ namespace SourceCode.Chasm.Tests.IO
         {
             // Arrange
             var mockChasmSerializer = new Mock<IChasmSerializer>();
-            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(TestValues.Commit);
+            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(CommitTestObject.Random);
             var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
             {
                 CallBase = true
@@ -185,7 +187,7 @@ namespace SourceCode.Chasm.Tests.IO
                 });
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.TreeId, TestValues.CancellationToken);
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(TreeIdTestObject.Random, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -221,7 +223,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.TreeId, TestValues.CancellationToken);
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(TreeIdTestObject.Random, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -253,7 +255,7 @@ namespace SourceCode.Chasm.Tests.IO
                 });
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(new TreeId[] { TestValues.TreeId }, TestValues.ParallelOptions);
+            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(new TreeId[] { TreeIdTestObject.Random }, TestValues.ParallelOptions);
 
             // Assert
             Assert.Equal(1, actual.Count);
@@ -297,7 +299,7 @@ namespace SourceCode.Chasm.Tests.IO
                 });
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(new TreeId[] { TestValues.TreeId }, TestValues.ParallelOptions);
+            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(new TreeId[] { TreeIdTestObject.Random }, TestValues.ParallelOptions);
 
             // Assert
             Assert.Equal(ReadOnlyDictionary.Empty<TreeId, TreeNodeList>(), actual);
@@ -308,7 +310,7 @@ namespace SourceCode.Chasm.Tests.IO
         public static async Task ChasmRepositoryTree_WriteTreeAsync_CommitIds()
         {
             // Arrange
-            var parents = new List<CommitId> { TestValues.CommitId };
+            var parents = new List<CommitId> { CommitIdTestObject.Random };
             var mockChasmSerializer = new Mock<IChasmSerializer>();
             var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
             {
@@ -316,7 +318,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = await mockChasmRepository.Object.WriteTreeAsync(parents, TestValues.TreeNodeList, TestValues.Audit, TestValues.Audit, TestValues.Message, TestValues.CancellationToken);
+            var actual = await mockChasmRepository.Object.WriteTreeAsync(parents, TreeNodeListTestObject.Random, AuditTestObject.Random, AuditTestObject.Random, RandomHelper.String, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(CommitId.Empty, actual);

--- a/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTreeTests.cs
+++ b/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTreeTests.cs
@@ -341,6 +341,53 @@ namespace SourceCode.Chasm.Tests.IO
             Assert.Equal(ReadOnlyDictionary.Empty<TreeId, TreeNodeList>(), actual);
         }
 
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_WriteTreeAsync_Tree))]
+        public static async Task ChasmRepositoryTree_WriteTreeAsync_CommitIds()
+        {
+            // Arrange
+            var sha1 = Sha1.Hash("abc");
+            var commitId = new CommitId(sha1);
+            var parents = new List<CommitId> { commitId };
+            var treeId = new TreeId(sha1);
+            var treeNodeList = new TreeNodeList(new TreeNode(Guid.NewGuid().ToString(), treeId));
+            var audit = new Audit(Guid.NewGuid().ToString(), DateTimeOffset.MaxValue);
+            var message = Guid.NewGuid().ToString();
+
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            // Action
+            var actual = await mockChasmRepository.Object.WriteTreeAsync(parents, treeNodeList, audit, audit, message, new CancellationToken());
+
+            // Assert
+            Assert.Equal(CommitId.Empty, actual);
+            mockChasmRepository.Verify(i => i.WriteTreeAsync(It.IsAny<TreeNodeList>(), It.IsAny<CancellationToken>()));
+            mockChasmRepository.Verify(i => i.WriteCommitAsync(It.IsAny<Commit>(), It.IsAny<CancellationToken>()));
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_WriteTreeAsync_Tree))]
+        public static async Task ChasmRepositoryTree_WriteTreeAsync_Tree()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            // Action
+            var actual = await mockChasmRepository.Object.WriteTreeAsync(TreeNodeList.Empty, new CancellationToken());
+
+            // Assert
+            Assert.Equal(TreeId.Empty, actual);
+            mockChasmRepository.Verify(i => i.WriteObjectAsync(It.IsAny<Sha1>(), It.IsAny<ArraySegment<byte>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()));
+        }
+
         #endregion
     }
 }

--- a/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTreeTests.cs
+++ b/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTreeTests.cs
@@ -1,0 +1,346 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using SourceCode.Chasm.IO;
+using SourceCode.Clay.Collections.Generic;
+using Xunit;
+
+namespace SourceCode.Chasm.Tests.IO
+{
+    public static class ChasmRepositoryTreeTests
+    {
+        #region Methods
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeAsync_Branch_CommitRefName))]
+        public static async Task ChasmRepositoryTree_ReadTreeAsync_Branch_CommitRefName()
+        {
+            // Arrange
+            var sha1 = Sha1.Hash("abc");
+            var commitId = new CommitId(sha1);
+            var treeId = new TreeId(sha1);
+            var audit = new Audit(Guid.NewGuid().ToString(), DateTimeOffset.MaxValue);
+            var commit = new Commit(commitId, treeId, audit, audit, Guid.NewGuid().ToString());
+            var commetRef = new CommitRef(Guid.NewGuid().ToString(), commitId);
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(commit);
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            mockChasmRepository.Setup(i => i.ReadCommitRefAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(async () =>
+                {
+                    await Task.Yield();
+                    return commetRef;
+                });
+
+            var branch = Guid.NewGuid().ToString();
+            var commitRefName = Guid.NewGuid().ToString();
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(branch, commitRefName, new CancellationToken());
+
+            // Assert
+            Assert.Equal(TreeNodeList.Empty, actual);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeAsync_Branch_CommitRefName_Empty))]
+        public static void ChasmRepositoryTree_ReadTreeAsync_Branch_CommitRefName_Empty()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+            var branch = Guid.NewGuid().ToString();
+            var commitRefName = default(string);
+
+            // Action
+            var actual = Assert.ThrowsAsync<ArgumentNullException>(async () => await mockChasmRepository.Object.ReadTreeAsync(branch, commitRefName, new CancellationToken()));
+
+            // Assert
+            Assert.Contains(nameof(commitRefName), actual.Result.Message);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeAsync_Branch_CommitRefName_EmptyBuffer))]
+        public static async Task ChasmRepositoryTree_ReadTreeAsync_Branch_CommitRefName_EmptyBuffer()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            var branch = Guid.NewGuid().ToString();
+            var commitRefName = Guid.NewGuid().ToString();
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(branch, commitRefName, new CancellationToken());
+
+            // Assert
+            Assert.Equal(TreeNodeList.Empty, actual);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeAsync_Branch_Empty))]
+        public static void ChasmRepositoryTree_ReadTreeAsync_Branch_Empty()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+            var branch = default(string);
+            var commitRefName = Guid.NewGuid().ToString();
+
+            // Action
+            var actual = Assert.ThrowsAsync<ArgumentNullException>(async () => await mockChasmRepository.Object.ReadTreeAsync(branch, commitRefName, new CancellationToken()));
+
+            // Assert
+            Assert.Contains(nameof(branch), actual.Result.Message);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeAsync_CommitId))]
+        public static async Task ChasmRepositoryTree_ReadTreeAsync_CommitId()
+        {
+            // Arrange
+            var sha1 = Sha1.Hash("abc");
+            var commitId = new CommitId(sha1);
+            var treeId = new TreeId(sha1);
+            var audit = new Audit();
+            var commit = new Commit(commitId, treeId, audit, audit, Guid.NewGuid().ToString());
+            var readOnlyMemory = new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3, 4 });
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(commit);
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            mockChasmRepository.Setup(i => i.ReadObjectAsync(It.IsAny<Sha1>(), It.IsAny<CancellationToken>()))
+                .Returns(async () =>
+                {
+                    await Task.Yield();
+                    return readOnlyMemory;
+                });
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(commitId, new CancellationToken());
+
+            // Assert
+            Assert.Equal(TreeNodeList.Empty, actual);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeAsync_CommitId_Empty))]
+        public static async Task ChasmRepositoryTree_ReadTreeAsync_CommitId_Empty()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(CommitId.Empty, new CancellationToken());
+
+            // Assert
+            Assert.Equal(TreeNodeList.Empty, actual);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeAsync_CommitId_EmptyBuffer))]
+        public static async Task ChasmRepositoryTree_ReadTreeAsync_CommitId_EmptyBuffer()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            var commitId = new CommitId(Sha1.Hash("abc"));
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(commitId, new CancellationToken());
+
+            // Assert
+            Assert.Equal(TreeNodeList.Empty, actual);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeAsync_TreeId))]
+        public static async Task ChasmRepositoryTree_ReadTreeAsync_TreeId()
+        {
+            // Arrange
+            var sha1 = Sha1.Hash("abc");
+            var commitId = new CommitId(sha1);
+            var treeId = new TreeId(sha1);
+            var audit = new Audit();
+            var commit = new Commit(commitId, treeId, audit, audit, Guid.NewGuid().ToString());
+            var readOnlyMemory = new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3, 4 });
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(commit);
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            mockChasmRepository.Setup(i => i.ReadObjectAsync(It.IsAny<Sha1>(), It.IsAny<CancellationToken>()))
+                .Returns(async () =>
+                {
+                    await Task.Yield();
+                    return readOnlyMemory;
+                });
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(treeId, new CancellationToken());
+
+            // Assert
+            Assert.Equal(TreeNodeList.Empty, actual);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeAsync_TreeId_Empty))]
+        public static async Task ChasmRepositoryTree_ReadTreeAsync_TreeId_Empty()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(TreeId.Empty, new CancellationToken());
+
+            // Assert
+            Assert.Equal(TreeNodeList.Empty, actual);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeAsync_TreeId_EmptyBuffer))]
+        public static async Task ChasmRepositoryTree_ReadTreeAsync_TreeId_EmptyBuffer()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            var treeId = new TreeId(Sha1.Hash("abc"));
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(treeId, new CancellationToken());
+
+            // Assert
+            Assert.Equal(TreeNodeList.Empty, actual);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeBatchAsync_TreeIds))]
+        public static async Task ChasmRepositoryTree_ReadTreeBatchAsync_TreeIds()
+        {
+            // Arrange
+            var sha1 = Sha1.Hash("abc");
+            var readOnlyMemory = new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3, 4 });
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            mockChasmRepository.Setup(i => i.ReadObjectBatchAsync(It.IsAny<IEnumerable<Sha1>>(), It.IsAny<ParallelOptions>()))
+                .Returns<IEnumerable<Sha1>, ParallelOptions>(async (objectIds, parallelOptions) =>
+                {
+                    await Task.Yield();
+
+                    var dictionary = new Dictionary<Sha1, ReadOnlyMemory<byte>>();
+                    foreach (var objectId in objectIds)
+                    {
+                        dictionary.Add(objectId, readOnlyMemory);
+                    }
+
+                    return new ReadOnlyDictionary<Sha1, ReadOnlyMemory<byte>>(dictionary);
+                });
+
+            var treeId = new TreeId(Sha1.Hash("abc"));
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(new TreeId[] { treeId }, new ParallelOptions());
+
+            // Assert
+            Assert.Equal(1, actual.Count);
+            Assert.Equal(TreeNodeList.Empty, actual.Values.FirstOrDefault());
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeBatchAsync_TreeIds_Empty))]
+        public static async Task ChasmRepositoryTree_ReadTreeBatchAsync_TreeIds_Empty()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(null, new ParallelOptions());
+
+            // Assert
+            Assert.Equal(ReadOnlyDictionary.Empty<TreeId, TreeNodeList>(), actual);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(ChasmRepositoryTree_ReadTreeBatchAsync_TreeIds_EmptyBuffer))]
+        public static async Task ChasmRepositoryTree_ReadTreeBatchAsync_TreeIds_EmptyBuffer()
+        {
+            // Arrange
+            var mockChasmSerializer = new Mock<IChasmSerializer>();
+            var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
+            {
+                CallBase = true
+            };
+
+            mockChasmRepository.Setup(i => i.ReadObjectBatchAsync(It.IsAny<IEnumerable<Sha1>>(), It.IsAny<ParallelOptions>()))
+                .Returns(async () =>
+                {
+                    await Task.Yield();
+                    return ReadOnlyDictionary.Empty<Sha1, ReadOnlyMemory<byte>>();
+                });
+
+            var treeId = new TreeId(Sha1.Hash("abc"));
+
+            // Action
+            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(new TreeId[] { treeId }, new ParallelOptions());
+
+            // Assert
+            Assert.Equal(ReadOnlyDictionary.Empty<TreeId, TreeNodeList>(), actual);
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTreeTests.cs
+++ b/src/SourceCode.Chasm.Tests/IO/ChasmRepositoryTreeTests.cs
@@ -28,14 +28,8 @@ namespace SourceCode.Chasm.Tests.IO
         public static async Task ChasmRepositoryTree_ReadTreeAsync_Branch_CommitRefName()
         {
             // Arrange
-            var sha1 = Sha1.Hash("abc");
-            var commitId = new CommitId(sha1);
-            var treeId = new TreeId(sha1);
-            var audit = new Audit(Guid.NewGuid().ToString(), DateTimeOffset.MaxValue);
-            var commit = new Commit(commitId, treeId, audit, audit, Guid.NewGuid().ToString());
-            var commetRef = new CommitRef(Guid.NewGuid().ToString(), commitId);
             var mockChasmSerializer = new Mock<IChasmSerializer>();
-            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(commit);
+            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(TestValues.Commit);
             var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
             {
                 CallBase = true
@@ -45,14 +39,11 @@ namespace SourceCode.Chasm.Tests.IO
                 .Returns(async () =>
                 {
                     await Task.Yield();
-                    return commetRef;
+                    return TestValues.CommitRef;
                 });
 
-            var branch = Guid.NewGuid().ToString();
-            var commitRefName = Guid.NewGuid().ToString();
-
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(branch, commitRefName, new CancellationToken());
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.Branch, TestValues.CommitRef.Name, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -68,14 +59,12 @@ namespace SourceCode.Chasm.Tests.IO
             {
                 CallBase = true
             };
-            var branch = Guid.NewGuid().ToString();
-            var commitRefName = default(string);
 
             // Action
-            var actual = Assert.ThrowsAsync<ArgumentNullException>(async () => await mockChasmRepository.Object.ReadTreeAsync(branch, commitRefName, new CancellationToken()));
+            var actual = Assert.ThrowsAsync<ArgumentNullException>(async () => await mockChasmRepository.Object.ReadTreeAsync(TestValues.Branch, default, TestValues.CancellationToken));
 
             // Assert
-            Assert.Contains(nameof(commitRefName), actual.Result.Message);
+            Assert.Contains("commitRefName", actual.Result.Message);
         }
 
         [Trait("Type", "Unit")]
@@ -89,11 +78,8 @@ namespace SourceCode.Chasm.Tests.IO
                 CallBase = true
             };
 
-            var branch = Guid.NewGuid().ToString();
-            var commitRefName = Guid.NewGuid().ToString();
-
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(branch, commitRefName, new CancellationToken());
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.Branch, TestValues.CommitRef.Name, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -109,14 +95,12 @@ namespace SourceCode.Chasm.Tests.IO
             {
                 CallBase = true
             };
-            var branch = default(string);
-            var commitRefName = Guid.NewGuid().ToString();
 
             // Action
-            var actual = Assert.ThrowsAsync<ArgumentNullException>(async () => await mockChasmRepository.Object.ReadTreeAsync(branch, commitRefName, new CancellationToken()));
+            var actual = Assert.ThrowsAsync<ArgumentNullException>(async () => await mockChasmRepository.Object.ReadTreeAsync(default, TestValues.CommitRef.Name, TestValues.CancellationToken));
 
             // Assert
-            Assert.Contains(nameof(branch), actual.Result.Message);
+            Assert.Contains("branch", actual.Result.Message);
         }
 
         [Trait("Type", "Unit")]
@@ -124,14 +108,8 @@ namespace SourceCode.Chasm.Tests.IO
         public static async Task ChasmRepositoryTree_ReadTreeAsync_CommitId()
         {
             // Arrange
-            var sha1 = Sha1.Hash("abc");
-            var commitId = new CommitId(sha1);
-            var treeId = new TreeId(sha1);
-            var audit = new Audit();
-            var commit = new Commit(commitId, treeId, audit, audit, Guid.NewGuid().ToString());
-            var readOnlyMemory = new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3, 4 });
             var mockChasmSerializer = new Mock<IChasmSerializer>();
-            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(commit);
+            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(TestValues.Commit);
             var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
             {
                 CallBase = true
@@ -141,11 +119,11 @@ namespace SourceCode.Chasm.Tests.IO
                 .Returns(async () =>
                 {
                     await Task.Yield();
-                    return readOnlyMemory;
+                    return TestValues.ReadOnlyMemory;
                 });
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(commitId, new CancellationToken());
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.CommitId, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -163,7 +141,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(CommitId.Empty, new CancellationToken());
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(CommitId.Empty, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -180,10 +158,8 @@ namespace SourceCode.Chasm.Tests.IO
                 CallBase = true
             };
 
-            var commitId = new CommitId(Sha1.Hash("abc"));
-
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(commitId, new CancellationToken());
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.CommitId, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -194,14 +170,8 @@ namespace SourceCode.Chasm.Tests.IO
         public static async Task ChasmRepositoryTree_ReadTreeAsync_TreeId()
         {
             // Arrange
-            var sha1 = Sha1.Hash("abc");
-            var commitId = new CommitId(sha1);
-            var treeId = new TreeId(sha1);
-            var audit = new Audit();
-            var commit = new Commit(commitId, treeId, audit, audit, Guid.NewGuid().ToString());
-            var readOnlyMemory = new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3, 4 });
             var mockChasmSerializer = new Mock<IChasmSerializer>();
-            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(commit);
+            mockChasmSerializer.Setup(i => i.DeserializeCommit(It.IsAny<ReadOnlySpan<byte>>())).Returns(TestValues.Commit);
             var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
             {
                 CallBase = true
@@ -211,11 +181,11 @@ namespace SourceCode.Chasm.Tests.IO
                 .Returns(async () =>
                 {
                     await Task.Yield();
-                    return readOnlyMemory;
+                    return TestValues.ReadOnlyMemory;
                 });
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(treeId, new CancellationToken());
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.TreeId, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -233,7 +203,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(TreeId.Empty, new CancellationToken());
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(TreeId.Empty, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -250,10 +220,8 @@ namespace SourceCode.Chasm.Tests.IO
                 CallBase = true
             };
 
-            var treeId = new TreeId(Sha1.Hash("abc"));
-
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeAsync(treeId, new CancellationToken());
+            var actual = await mockChasmRepository.Object.ReadTreeAsync(TestValues.TreeId, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeNodeList.Empty, actual);
@@ -264,8 +232,6 @@ namespace SourceCode.Chasm.Tests.IO
         public static async Task ChasmRepositoryTree_ReadTreeBatchAsync_TreeIds()
         {
             // Arrange
-            var sha1 = Sha1.Hash("abc");
-            var readOnlyMemory = new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3, 4 });
             var mockChasmSerializer = new Mock<IChasmSerializer>();
             var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
             {
@@ -280,16 +246,14 @@ namespace SourceCode.Chasm.Tests.IO
                     var dictionary = new Dictionary<Sha1, ReadOnlyMemory<byte>>();
                     foreach (var objectId in objectIds)
                     {
-                        dictionary.Add(objectId, readOnlyMemory);
+                        dictionary.Add(objectId, TestValues.ReadOnlyMemory);
                     }
 
                     return new ReadOnlyDictionary<Sha1, ReadOnlyMemory<byte>>(dictionary);
                 });
 
-            var treeId = new TreeId(Sha1.Hash("abc"));
-
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(new TreeId[] { treeId }, new ParallelOptions());
+            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(new TreeId[] { TestValues.TreeId }, TestValues.ParallelOptions);
 
             // Assert
             Assert.Equal(1, actual.Count);
@@ -308,7 +272,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(null, new ParallelOptions());
+            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(null, TestValues.ParallelOptions);
 
             // Assert
             Assert.Equal(ReadOnlyDictionary.Empty<TreeId, TreeNodeList>(), actual);
@@ -332,10 +296,8 @@ namespace SourceCode.Chasm.Tests.IO
                     return ReadOnlyDictionary.Empty<Sha1, ReadOnlyMemory<byte>>();
                 });
 
-            var treeId = new TreeId(Sha1.Hash("abc"));
-
             // Action
-            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(new TreeId[] { treeId }, new ParallelOptions());
+            var actual = await mockChasmRepository.Object.ReadTreeBatchAsync(new TreeId[] { TestValues.TreeId }, TestValues.ParallelOptions);
 
             // Assert
             Assert.Equal(ReadOnlyDictionary.Empty<TreeId, TreeNodeList>(), actual);
@@ -346,14 +308,7 @@ namespace SourceCode.Chasm.Tests.IO
         public static async Task ChasmRepositoryTree_WriteTreeAsync_CommitIds()
         {
             // Arrange
-            var sha1 = Sha1.Hash("abc");
-            var commitId = new CommitId(sha1);
-            var parents = new List<CommitId> { commitId };
-            var treeId = new TreeId(sha1);
-            var treeNodeList = new TreeNodeList(new TreeNode(Guid.NewGuid().ToString(), treeId));
-            var audit = new Audit(Guid.NewGuid().ToString(), DateTimeOffset.MaxValue);
-            var message = Guid.NewGuid().ToString();
-
+            var parents = new List<CommitId> { TestValues.CommitId };
             var mockChasmSerializer = new Mock<IChasmSerializer>();
             var mockChasmRepository = new Mock<ChasmRepository>(mockChasmSerializer.Object, CompressionLevel.NoCompression, 5)
             {
@@ -361,7 +316,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = await mockChasmRepository.Object.WriteTreeAsync(parents, treeNodeList, audit, audit, message, new CancellationToken());
+            var actual = await mockChasmRepository.Object.WriteTreeAsync(parents, TestValues.TreeNodeList, TestValues.Audit, TestValues.Audit, TestValues.Message, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(CommitId.Empty, actual);
@@ -381,7 +336,7 @@ namespace SourceCode.Chasm.Tests.IO
             };
 
             // Action
-            var actual = await mockChasmRepository.Object.WriteTreeAsync(TreeNodeList.Empty, new CancellationToken());
+            var actual = await mockChasmRepository.Object.WriteTreeAsync(TreeNodeList.Empty, TestValues.CancellationToken);
 
             // Assert
             Assert.Equal(TreeId.Empty, actual);

--- a/src/SourceCode.Chasm.Tests/TestObjects/AuditTestObject.cs
+++ b/src/SourceCode.Chasm.Tests/TestObjects/AuditTestObject.cs
@@ -1,0 +1,22 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Chasm.Tests.Helpers;
+
+namespace SourceCode.Chasm.Tests.TestObjects
+{
+    public static class AuditTestObject
+    {
+        #region Fields
+
+        public static readonly Audit Random = new Audit(
+            RandomHelper.String,
+            RandomHelper.DateTimeOffset);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/TestObjects/CommitIdTestObject.cs
+++ b/src/SourceCode.Chasm.Tests/TestObjects/CommitIdTestObject.cs
@@ -1,0 +1,20 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Chasm.Tests.Helpers;
+
+namespace SourceCode.Chasm.Tests.TestObjects
+{
+    public static class CommitIdTestObject
+    {
+        #region Fields
+
+        public static readonly CommitId Random = new CommitId(Sha1TestObject.Random);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/TestObjects/CommitRefTestObject.cs
+++ b/src/SourceCode.Chasm.Tests/TestObjects/CommitRefTestObject.cs
@@ -1,0 +1,23 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using SourceCode.Chasm.Tests.Helpers;
+
+namespace SourceCode.Chasm.Tests.TestObjects
+{
+    public static class CommitRefTestObject
+    {
+        #region Fields
+
+        public static readonly CommitRef Random = new CommitRef(
+            RandomHelper.String,
+            CommitIdTestObject.Random);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/TestObjects/CommitTestObject.cs
+++ b/src/SourceCode.Chasm.Tests/TestObjects/CommitTestObject.cs
@@ -1,0 +1,26 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using SourceCode.Chasm.Tests.Helpers;
+
+namespace SourceCode.Chasm.Tests.TestObjects
+{
+    public static class CommitTestObject
+    {
+        #region Fields
+
+        public static readonly Commit Random = new Commit(
+            CommitIdTestObject.Random,
+            TreeIdTestObject.Random,
+            AuditTestObject.Random,
+            AuditTestObject.Random,
+            RandomHelper.String);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/TestObjects/Sha1TestObject.cs
+++ b/src/SourceCode.Chasm.Tests/TestObjects/Sha1TestObject.cs
@@ -1,0 +1,20 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Chasm.Tests.Helpers;
+
+namespace SourceCode.Chasm.Tests.TestObjects
+{
+    public static class Sha1TestObject
+    {
+        #region Fields
+
+        public static readonly Sha1 Random = Sha1.Hash(RandomHelper.String);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/TestObjects/TreeIdTestObject.cs
+++ b/src/SourceCode.Chasm.Tests/TestObjects/TreeIdTestObject.cs
@@ -1,0 +1,20 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Chasm.Tests.Helpers;
+
+namespace SourceCode.Chasm.Tests.TestObjects
+{
+    public static class TreeIdTestObject
+    {
+        #region Fields
+
+        public static readonly TreeId Random = new TreeId(Sha1TestObject.Random);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/TestObjects/TreeNodeListTestObject.cs
+++ b/src/SourceCode.Chasm.Tests/TestObjects/TreeNodeListTestObject.cs
@@ -1,0 +1,20 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Chasm.Tests.Helpers;
+
+namespace SourceCode.Chasm.Tests.TestObjects
+{
+    public static class TreeNodeListTestObject
+    {
+        #region Fields
+
+        public static readonly TreeNodeList Random = new TreeNodeList(TreeNodeTestObject.Random);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/TestObjects/TreeNodeTestObject.cs
+++ b/src/SourceCode.Chasm.Tests/TestObjects/TreeNodeTestObject.cs
@@ -1,0 +1,22 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Chasm.Tests.Helpers;
+
+namespace SourceCode.Chasm.Tests.TestObjects
+{
+    public static class TreeNodeTestObject
+    {
+        #region Fields
+
+        public static readonly TreeNode Random = new TreeNode(
+            RandomHelper.String,
+            TreeIdTestObject.Random);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Chasm.Tests/TestValues.cs
+++ b/src/SourceCode.Chasm.Tests/TestValues.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SourceCode.Chasm.Tests
+{
+    /// <summary>
+    /// Values used for testing.
+    /// </summary>
+    public static class TestValues
+    {
+        public static readonly Audit Audit = new Audit(Guid.NewGuid().ToString(), DateTimeOffset.MaxValue);
+        public static readonly string Branch = Guid.NewGuid().ToString();
+        public static readonly CancellationToken CancellationToken = new CancellationToken(false);
+        public static readonly Commit Commit = new Commit(CommitId, TreeId, Audit, Audit, Guid.NewGuid().ToString());
+        public static readonly CommitId CommitId = new CommitId(Sha1);
+        public static readonly CommitRef CommitRef = new CommitRef(Guid.NewGuid().ToString(), CommitId);
+        public static readonly string HashValue = Guid.NewGuid().ToString();
+        public static readonly string Message = Guid.NewGuid().ToString();
+        public static readonly ParallelOptions ParallelOptions = new ParallelOptions() { CancellationToken = CancellationToken };
+        public static readonly ReadOnlyMemory<byte> ReadOnlyMemory = new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3, 4 });
+        public static readonly Sha1 Sha1 = Sha1.Hash(HashValue);
+        public static readonly TreeId TreeId = new TreeId(Sha1);
+        public static readonly TreeNode TreeNode = new TreeNode(Guid.NewGuid().ToString(), TreeId);
+        public static readonly TreeNodeList TreeNodeList = new TreeNodeList(TreeNode);
+    }
+}

--- a/src/SourceCode.Chasm.Tests/TestValues.cs
+++ b/src/SourceCode.Chasm.Tests/TestValues.cs
@@ -1,6 +1,14 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using SourceCode.Chasm.Tests.Helpers;
 
 namespace SourceCode.Chasm.Tests
 {
@@ -9,19 +17,17 @@ namespace SourceCode.Chasm.Tests
     /// </summary>
     public static class TestValues
     {
-        public static readonly Audit Audit = new Audit(Guid.NewGuid().ToString(), DateTimeOffset.MaxValue);
-        public static readonly string Branch = Guid.NewGuid().ToString();
+        #region Fields
+
         public static readonly CancellationToken CancellationToken = new CancellationToken(false);
-        public static readonly Commit Commit = new Commit(CommitId, TreeId, Audit, Audit, Guid.NewGuid().ToString());
-        public static readonly CommitId CommitId = new CommitId(Sha1);
-        public static readonly CommitRef CommitRef = new CommitRef(Guid.NewGuid().ToString(), CommitId);
-        public static readonly string HashValue = Guid.NewGuid().ToString();
-        public static readonly string Message = Guid.NewGuid().ToString();
-        public static readonly ParallelOptions ParallelOptions = new ParallelOptions() { CancellationToken = CancellationToken };
-        public static readonly ReadOnlyMemory<byte> ReadOnlyMemory = new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3, 4 });
-        public static readonly Sha1 Sha1 = Sha1.Hash(HashValue);
-        public static readonly TreeId TreeId = new TreeId(Sha1);
-        public static readonly TreeNode TreeNode = new TreeNode(Guid.NewGuid().ToString(), TreeId);
-        public static readonly TreeNodeList TreeNodeList = new TreeNodeList(TreeNode);
+
+        public static readonly ParallelOptions ParallelOptions = new ParallelOptions()
+        {
+            CancellationToken = CancellationToken
+        };
+
+        public static readonly ReadOnlyMemory<byte> ReadOnlyMemory = new ReadOnlyMemory<byte>(RandomHelper.ByteArray);
+
+        #endregion
     }
 }


### PR DESCRIPTION
Added unit tests to cover the following code files.

Audit.cs
ChasmRepository.Tree.cs
ChasmRepository.Commit.cs