### PR TITLE
Nuget (PrivateAssets=All)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at oss@k2.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+### Expected Behavior
+
+Describe what you expect to happen.
+
+### Actual Behavior
+
+Describe what actually happens.
+
+### Error
+
+```
+Paste in error details, if available.
+```
+
+### Repro Steps
+
+1. Provide
+2. Steps
+3. To
+4. Repro

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Fixes #
+
+### Information
+
+Provide a description of the pull request.
+
+### Proposed Changes
+
+* Describe individual changes made

--- a/src/SourceCode.Chasm.Repository.AzureBlob/SourceCode.Chasm.Repository.AzureBlob.csproj
+++ b/src/SourceCode.Chasm.Repository.AzureBlob/SourceCode.Chasm.Repository.AzureBlob.csproj
@@ -11,7 +11,9 @@
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01" />
+    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/SourceCode.Chasm.Repository.AzureBlob/SourceCode.Chasm.Repository.AzureBlob.csproj
+++ b/src/SourceCode.Chasm.Repository.AzureBlob/SourceCode.Chasm.Repository.AzureBlob.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.5.0.3766">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00268" />
+    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00269" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 

--- a/src/SourceCode.Chasm.Repository.AzureTable/SourceCode.Chasm.Repository.AzureTable.csproj
+++ b/src/SourceCode.Chasm.Repository.AzureTable/SourceCode.Chasm.Repository.AzureTable.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.5.0.3766">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00268" />
-    <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00268" />
+    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00269" />
+    <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00269" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 

--- a/src/SourceCode.Chasm.Repository.AzureTable/SourceCode.Chasm.Repository.AzureTable.csproj
+++ b/src/SourceCode.Chasm.Repository.AzureTable/SourceCode.Chasm.Repository.AzureTable.csproj
@@ -11,7 +11,9 @@
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01" />
+    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/SourceCode.Chasm.Repository.Disk/SourceCode.Chasm.Repository.Disk.csproj
+++ b/src/SourceCode.Chasm.Repository.Disk/SourceCode.Chasm.Repository.Disk.csproj
@@ -11,7 +11,9 @@
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01" />
+    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/SourceCode.Chasm.Repository.Hybrid/SourceCode.Chasm.Repository.Hybrid.csproj
+++ b/src/SourceCode.Chasm.Repository.Hybrid/SourceCode.Chasm.Repository.Hybrid.csproj
@@ -11,7 +11,9 @@
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01" />
+    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/SourceCode.Chasm.Serializer.Json/SourceCode.Chasm.Serializer.Json.csproj
+++ b/src/SourceCode.Chasm.Serializer.Json/SourceCode.Chasm.Serializer.Json.csproj
@@ -11,7 +11,9 @@
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01" />
+    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/SourceCode.Chasm.Serializer.Json/SourceCode.Chasm.Serializer.Json.csproj
+++ b/src/SourceCode.Chasm.Serializer.Json/SourceCode.Chasm.Serializer.Json.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.5.0.3766">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00268" />
+    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00269" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm.Serializer.Proto/SourceCode.Chasm.Serializer.Proto.csproj
+++ b/src/SourceCode.Chasm.Serializer.Proto/SourceCode.Chasm.Serializer.Proto.csproj
@@ -11,7 +11,9 @@
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01" />
+    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/SourceCode.Chasm.Serializer.Text/SourceCode.Chasm.Serializer.Text.csproj
+++ b/src/SourceCode.Chasm.Serializer.Text/SourceCode.Chasm.Serializer.Text.csproj
@@ -11,7 +11,9 @@
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01" />
+    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -20,9 +20,9 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.5.0.3766">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00268" />
-    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00268" />
-    <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00268" />
+    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00269" />
+    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00269" />
+    <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00269" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -11,7 +11,9 @@
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01" />
+    <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-25818-01">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Fixes: Build-specific Nugets should use `PrivateAssets=All`
