### PR TITLE
Convert from System.Json to Newtonsoft.Linq

### DIFF
--- a/src/SourceCode.Chasm.Repository.AzureBlob/SourceCode.Chasm.Repository.AzureBlob.csproj
+++ b/src/SourceCode.Chasm.Repository.AzureBlob/SourceCode.Chasm.Repository.AzureBlob.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.5.0.3766">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00272" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 

--- a/src/SourceCode.Chasm.Repository.AzureTable/SourceCode.Chasm.Repository.AzureTable.csproj
+++ b/src/SourceCode.Chasm.Repository.AzureTable/SourceCode.Chasm.Repository.AzureTable.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.5.0.3766">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00272" />
+    <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00276" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 

--- a/src/SourceCode.Chasm.Repository.AzureTable/SourceCode.Chasm.Repository.AzureTable.csproj
+++ b/src/SourceCode.Chasm.Repository.AzureTable/SourceCode.Chasm.Repository.AzureTable.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.5.0.3766">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00272" />
     <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00272" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>

--- a/src/SourceCode.Chasm.Serializer.Json/SourceCode.Chasm.Serializer.Json.csproj
+++ b/src/SourceCode.Chasm.Serializer.Json/SourceCode.Chasm.Serializer.Json.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.5.0.3766">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00272" />
+    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00276" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm.Serializer.Json/Wire/CommitIdWireExtensions.cs
+++ b/src/SourceCode.Chasm.Serializer.Json/Wire/CommitIdWireExtensions.cs
@@ -5,8 +5,7 @@
 
 #endregion
 
-using SourceCode.Clay.Json;
-using System.Json;
+using Newtonsoft.Json.Linq;
 
 namespace SourceCode.Chasm.IO.Json.Wire
 {
@@ -22,9 +21,9 @@ namespace SourceCode.Chasm.IO.Json.Wire
 
         #region Methods
 
-        public static JsonObject Convert(this CommitId model)
+        public static JObject Convert(this CommitId model)
         {
-            var wire = new JsonObject
+            var wire = new JObject
             {
                 [_id] = model.Sha1.ToString("N")
             };
@@ -32,12 +31,13 @@ namespace SourceCode.Chasm.IO.Json.Wire
             return wire;
         }
 
-        public static CommitId ConvertCommitId(this JsonObject wire)
+        public static CommitId ConvertCommitId(this JObject wire)
         {
             if (wire == null) return default;
 
-            var jv = wire.GetValue(_id, JsonType.String, false);
-            var sha1 = Sha1.Parse(jv);
+            var jv = wire.GetValue(_id);
+            var str = (string)jv;
+            var sha1 = Sha1.Parse(str);
 
             var model = new CommitId(sha1);
             return model;
@@ -45,9 +45,9 @@ namespace SourceCode.Chasm.IO.Json.Wire
 
         public static CommitId ParseCommitId(this string json)
         {
-            var wire = json.ParseJsonObject();
+            var wire = JToken.Parse(json);
 
-            var model = wire.ConvertCommitId();
+            var model = ((JObject)wire).ConvertCommitId();
             return model;
         }
 

--- a/src/SourceCode.Chasm.Serializer.Json/Wire/TreeWireExtensions.cs
+++ b/src/SourceCode.Chasm.Serializer.Json/Wire/TreeWireExtensions.cs
@@ -5,8 +5,7 @@
 
 #endregion
 
-using SourceCode.Clay.Json;
-using System.Json;
+using Newtonsoft.Json.Linq;
 
 namespace SourceCode.Chasm.IO.Json.Wire
 {
@@ -14,26 +13,26 @@ namespace SourceCode.Chasm.IO.Json.Wire
     {
         #region Methods
 
-        public static JsonValue Convert(this TreeNodeMap model)
+        public static JArray Convert(this TreeNodeMap model)
         {
-            if (model.Count == 0) return new JsonArray();
+            if (model.Count == 0) return new JArray();
 
-            var items = new JsonValue[model.Count];
+            var items = new JObject[model.Count];
             for (var i = 0; i < items.Length; i++)
                 items[i] = model[i].Convert();
 
-            var wire = new JsonArray(items);
+            var wire = new JArray(items);
             return wire;
         }
 
-        public static TreeNodeMap ConvertTree(this JsonArray wire)
+        public static TreeNodeMap ConvertTree(this JArray wire)
         {
             if (wire == null) return default;
             if (wire.Count == 0) return default;
 
             var nodes = new TreeNode[wire.Count];
             for (var i = 0; i < nodes.Length; i++)
-                nodes[i] = ((JsonObject)wire[i]).ConvertTreeNode();
+                nodes[i] = ((JObject)wire[i]).ConvertTreeNode();
 
             var model = new TreeNodeMap(nodes);
             return model;
@@ -41,9 +40,9 @@ namespace SourceCode.Chasm.IO.Json.Wire
 
         public static TreeNodeMap ParseTree(this string json)
         {
-            var wire = json.ParseJsonArray();
+            var wire = JToken.Parse(json);
 
-            var model = wire.ConvertTree();
+            var model = ((JArray)wire).ConvertTree();
             return model;
         }
 

--- a/src/SourceCode.Chasm.Serializer.Json/Wire/TreeWireNodeExtensions.cs
+++ b/src/SourceCode.Chasm.Serializer.Json/Wire/TreeWireNodeExtensions.cs
@@ -5,9 +5,8 @@
 
 #endregion
 
-using SourceCode.Clay.Json;
+using Newtonsoft.Json.Linq;
 using System;
-using System.Json;
 
 namespace SourceCode.Chasm.IO.Json.Wire
 {
@@ -25,11 +24,11 @@ namespace SourceCode.Chasm.IO.Json.Wire
 
         #region Methods
 
-        public static JsonObject Convert(this TreeNode model)
+        public static JObject Convert(this TreeNode model)
         {
             if (model == TreeNode.Empty) return default;
 
-            var wire = new JsonObject
+            var wire = new JObject
             {
                 [_name] = model.Name,
                 [_kind] = model.Kind.ToString(),
@@ -39,17 +38,19 @@ namespace SourceCode.Chasm.IO.Json.Wire
             return wire;
         }
 
-        public static TreeNode ConvertTreeNode(this JsonObject wire)
+        public static TreeNode ConvertTreeNode(this JObject wire)
         {
             if (wire == null) return default;
 
-            var name = (string)wire.GetValue(_name, JsonType.String, false);
+            var name = (string)wire.GetValue(_name);
 
-            var jv = wire.GetValue(_kind, JsonType.String, false);
-            var kind = (NodeKind)Enum.Parse(typeof(NodeKind), jv, true);
+            var jv = wire.GetValue(_kind);
+            var str = (string)jv;
+            var kind = (NodeKind)Enum.Parse(typeof(NodeKind), str, true);
 
-            jv = wire.GetValue(_nodeId, JsonType.String, false);
-            var sha1 = Sha1.Parse(jv);
+            jv = wire.GetValue(_nodeId);
+            str = (string)jv;
+            var sha1 = Sha1.Parse(str);
 
             var model = new TreeNode(name, kind, sha1);
             return model;

--- a/src/SourceCode.Chasm.Serializer.Tests/CommitTests.Message.cs
+++ b/src/SourceCode.Chasm.Serializer.Tests/CommitTests.Message.cs
@@ -5,7 +5,6 @@
 
 #endregion
 
-using System;
 using Xunit;
 
 namespace SourceCode.Chasm.IO.Tests

--- a/src/SourceCode.Chasm/Audit.cs
+++ b/src/SourceCode.Chasm/Audit.cs
@@ -5,6 +5,7 @@
 
 #endregion
 
+using SourceCode.Clay;
 using System;
 using System.Diagnostics;
 
@@ -69,18 +70,10 @@ namespace SourceCode.Chasm
             => obj is Audit audit
             && Equals(audit);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hc = 17L;
-
-                hc = (hc * 23) + StringComparer.Ordinal.GetHashCode(Name);
-                hc = (hc * 23) + Timestamp.GetHashCode();
-
-                return ((int)(hc >> 32)) ^ (int)hc;
-            }
-        }
+        public override int GetHashCode() => new HashCode()
+            .Tally(Name ?? string.Empty, StringComparer.Ordinal)
+            .Tally(Timestamp)
+            .ToHashCode();
 
         #endregion
 

--- a/src/SourceCode.Chasm/Audit.cs
+++ b/src/SourceCode.Chasm/Audit.cs
@@ -70,10 +70,15 @@ namespace SourceCode.Chasm
             => obj is Audit audit
             && Equals(audit);
 
-        public override int GetHashCode() => new HashCode()
-            .Tally(Name ?? string.Empty, StringComparer.Ordinal)
-            .Tally(Timestamp)
-            .ToHashCode();
+        public override int GetHashCode()
+        {
+            var hc = new HashCode();
+
+            hc.Add(Name ?? string.Empty, StringComparer.Ordinal);
+            hc.Add(Timestamp);
+
+            return hc.ToHashCode();
+        }
 
         #endregion
 

--- a/src/SourceCode.Chasm/Commit.cs
+++ b/src/SourceCode.Chasm/Commit.cs
@@ -11,7 +11,7 @@ using System.Diagnostics;
 
 namespace SourceCode.Chasm
 {
-    [DebuggerDisplay("{" + nameof(Author) + ".ToString(),nq,ac} ({" + nameof(TreeId) + "." + nameof(Chasm.TreeId.Sha1) + ".ToString(\"D\"),nq,ac})")]
+    [DebuggerDisplay("{" + nameof(Author) + ".ToString(),nq,ac} ({" + nameof(TreeId) + "?." + nameof(Chasm.TreeId.Sha1) + ".ToString(\"D\"),nq,ac})")]
     public struct Commit : IEquatable<Commit>
     {
         #region Constants

--- a/src/SourceCode.Chasm/CommitComparer.cs
+++ b/src/SourceCode.Chasm/CommitComparer.cs
@@ -5,6 +5,7 @@
 
 #endregion
 
+using SourceCode.Clay;
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -66,21 +67,13 @@ namespace SourceCode.Chasm
                 return true;
             }
 
-            public override int GetHashCode(Commit obj)
-            {
-                unchecked
-                {
-                    var hc = 17L;
-
-                    hc = (hc * 23) + obj.TreeId.GetHashCode();
-                    hc = (hc * 23) + obj.Author.GetHashCode();
-                    hc = (hc * 23) + obj.Committer.GetHashCode();
-                    hc = (hc * 23) + (obj.Parents?.Count ?? -42);
-                    hc = (hc * 23) + (obj.Message?.Length ?? 0);
-
-                    return ((int)(hc >> 32)) ^ (int)hc;
-                }
-            }
+            public override int GetHashCode(Commit obj) => new HashCode()
+                .Tally(obj.TreeId ?? default, TreeIdComparer.Default)
+                .Tally(obj.Author)
+                .Tally(obj.Committer)
+                .TallyCount(obj.Parents)
+                .Tally(obj.Message ?? string.Empty, StringComparer.Ordinal)
+                .ToHashCode();
 
             #endregion
         }

--- a/src/SourceCode.Chasm/CommitComparer.cs
+++ b/src/SourceCode.Chasm/CommitComparer.cs
@@ -67,13 +67,18 @@ namespace SourceCode.Chasm
                 return true;
             }
 
-            public override int GetHashCode(Commit obj) => new HashCode()
-                .Tally(obj.TreeId ?? default, TreeIdComparer.Default)
-                .Tally(obj.Author)
-                .Tally(obj.Committer)
-                .TallyCount(obj.Parents)
-                .Tally(obj.Message ?? string.Empty, StringComparer.Ordinal)
-                .ToHashCode();
+            public override int GetHashCode(Commit obj)
+            {
+                var hc = new HashCode();
+
+                hc.Add(obj.TreeId ?? default, TreeIdComparer.Default);
+                hc.Add(obj.Author);
+                hc.Add(obj.Committer);
+                hc.Add(obj.Parents == null ? 0 : obj.Parents.Count);
+                hc.Add(obj.Message ?? string.Empty, StringComparer.Ordinal);
+
+                return hc.ToHashCode();
+            }
 
             #endregion
         }

--- a/src/SourceCode.Chasm/CommitRef.cs
+++ b/src/SourceCode.Chasm/CommitRef.cs
@@ -60,10 +60,15 @@ namespace SourceCode.Chasm
             => obj is CommitRef commitRef
             && Equals(commitRef);
 
-        public override int GetHashCode() => new HashCode()
-            .Tally(CommitId, CommitIdComparer.Default)
-            .Tally(Name ?? string.Empty, StringComparer.Ordinal)
-            .ToHashCode();
+        public override int GetHashCode()
+        {
+            var hc = new HashCode();
+
+            hc.Add(CommitId, CommitIdComparer.Default);
+            hc.Add(Name ?? string.Empty, StringComparer.Ordinal);
+
+            return hc.ToHashCode();
+        }
 
         #endregion
 

--- a/src/SourceCode.Chasm/CommitRef.cs
+++ b/src/SourceCode.Chasm/CommitRef.cs
@@ -5,6 +5,7 @@
 
 #endregion
 
+using SourceCode.Clay;
 using System;
 using System.Diagnostics;
 
@@ -59,18 +60,10 @@ namespace SourceCode.Chasm
             => obj is CommitRef commitRef
             && Equals(commitRef);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hc = 17L;
-
-                hc = (hc * 23) + CommitId.GetHashCode();
-                hc = (hc * 23) + (Name?.Length ?? 0);
-
-                return ((int)(hc >> 32)) ^ (int)hc;
-            }
-        }
+        public override int GetHashCode() => new HashCode()
+            .Tally(CommitId, CommitIdComparer.Default)
+            .Tally(Name ?? string.Empty, StringComparer.Ordinal)
+            .ToHashCode();
 
         #endregion
 

--- a/src/SourceCode.Chasm/Sha1Comparer.cs
+++ b/src/SourceCode.Chasm/Sha1Comparer.cs
@@ -84,11 +84,16 @@ namespace SourceCode.Chasm
                 && x.Blit2 == y.Blit2;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public override int GetHashCode(Sha1 obj) => new HashCode()
-                .Tally(obj.Blit0)
-                .Tally(obj.Blit1)
-                .Tally(obj.Blit2)
-                .ToHashCode();
+            public override int GetHashCode(Sha1 obj)
+            {
+                var hc = new HashCode();
+
+                hc.Add(obj.Blit0);
+                hc.Add(obj.Blit1);
+                hc.Add(obj.Blit2);
+
+                return hc.ToHashCode();
+            }
 
             #endregion
         }

--- a/src/SourceCode.Chasm/Sha1Comparer.cs
+++ b/src/SourceCode.Chasm/Sha1Comparer.cs
@@ -5,6 +5,7 @@
 
 #endregion
 
+using SourceCode.Clay;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -83,19 +84,11 @@ namespace SourceCode.Chasm
                 && x.Blit2 == y.Blit2;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public override int GetHashCode(Sha1 obj)
-            {
-                unchecked
-                {
-                    var hc = 17L;
-
-                    hc = (hc * 23) + (long)obj.Blit0;
-                    hc = (hc * 23) + (long)obj.Blit1;
-                    hc = (hc * 23) + obj.Blit2;
-
-                    return ((int)(hc >> 32)) ^ (int)hc;
-                }
-            }
+            public override int GetHashCode(Sha1 obj) => new HashCode()
+                .Tally(obj.Blit0)
+                .Tally(obj.Blit1)
+                .Tally(obj.Blit2)
+                .ToHashCode();
 
             #endregion
         }

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -20,10 +20,10 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.5.0.3766">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00272" />
-    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00272" />
-    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00272" />
-    <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00272" />
+    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00276" />
+    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00276" />
+    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00276" />
+    <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00276" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.5.0.3766">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00272" />
     <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00272" />
     <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00272" />
     <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00272" />

--- a/src/SourceCode.Chasm/TreeNodeComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeComparer.cs
@@ -5,6 +5,7 @@
 
 #endregion
 
+using SourceCode.Clay;
 using System;
 using System.Collections.Generic;
 
@@ -85,19 +86,11 @@ namespace SourceCode.Chasm
                 return true;
             }
 
-            public override int GetHashCode(TreeNode obj)
-            {
-                unchecked
-                {
-                    var hc = 17L;
-
-                    hc = (hc * 23) + (obj.Name == null ? 0 : StringComparer.Ordinal.GetHashCode(obj.Name));
-                    hc = (hc * 23) + (int)obj.Kind;
-                    hc = (hc * 23) + obj.Sha1.GetHashCode();
-
-                    return ((int)(hc >> 32)) ^ (int)hc;
-                }
-            }
+            public override int GetHashCode(TreeNode obj) => new HashCode()
+                .Tally(obj.Name ?? string.Empty, StringComparer.Ordinal)
+                .Tally((int)obj.Kind)
+                .Tally(obj.Sha1, Sha1Comparer.Default)
+                .ToHashCode();
 
             #endregion
         }

--- a/src/SourceCode.Chasm/TreeNodeComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeComparer.cs
@@ -86,11 +86,16 @@ namespace SourceCode.Chasm
                 return true;
             }
 
-            public override int GetHashCode(TreeNode obj) => new HashCode()
-                .Tally(obj.Name ?? string.Empty, StringComparer.Ordinal)
-                .Tally((int)obj.Kind)
-                .Tally(obj.Sha1, Sha1Comparer.Default)
-                .ToHashCode();
+            public override int GetHashCode(TreeNode obj)
+            {
+                var hc = new HashCode();
+
+                hc.Add(obj.Name ?? string.Empty, StringComparer.Ordinal);
+                hc.Add((int)obj.Kind);
+                hc.Add(obj.Sha1, Sha1Comparer.Default);
+
+                return hc.ToHashCode();
+            }
 
             #endregion
         }

--- a/src/SourceCode.Chasm/TreeNodeMapComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeMapComparer.cs
@@ -58,9 +58,14 @@ namespace SourceCode.Chasm
             public override bool Equals(TreeNodeMap x, TreeNodeMap y)
                 => x._nodes.MemoryEquals(y._nodes);
 
-            public override int GetHashCode(TreeNodeMap obj) => new HashCode()
-                .Tally(obj._nodes.Length)
-                .ToHashCode();
+            public override int GetHashCode(TreeNodeMap obj)
+            {
+                var hc = new HashCode();
+
+                hc.Add(obj._nodes.Length);
+
+                return hc.ToHashCode();
+            }
 
             #endregion
         }

--- a/src/SourceCode.Chasm/TreeNodeMapComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeMapComparer.cs
@@ -5,6 +5,7 @@
 
 #endregion
 
+using SourceCode.Clay;
 using SourceCode.Clay.Collections.Generic;
 using System.Collections.Generic;
 
@@ -57,20 +58,9 @@ namespace SourceCode.Chasm
             public override bool Equals(TreeNodeMap x, TreeNodeMap y)
                 => x._nodes.MemoryEquals(y._nodes);
 
-            public override int GetHashCode(TreeNodeMap obj)
-            {
-                unchecked
-                {
-                    var hc = 17L;
-
-                    hc = (hc * 23) + obj._nodes.Length;
-
-                    if (obj._nodes.Length > 0)
-                        hc = (hc * 23) + obj._nodes.Span[0].GetHashCode();
-
-                    return ((int)(hc >> 32)) ^ (int)hc;
-                }
-            }
+            public override int GetHashCode(TreeNodeMap obj) => new HashCode()
+                .Tally(obj._nodes.Length)
+                .ToHashCode();
 
             #endregion
         }


### PR DESCRIPTION
Fixes #123

### Information

`System.Json` has too many issues to keep using.

### Proposed Changes

Convert all calls to use `Newtonsoft.Linq.JToken` (et al) instead.