### PR TITLE
Nuget & align

### DIFF
--- a/SourceCode.Chasm.sln
+++ b/SourceCode.Chasm.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27102.0
+VisualStudioVersion = 15.0.27110.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SourceCode.Chasm", "src\SourceCode.Chasm\SourceCode.Chasm.csproj", "{430F8C16-427D-4756-B788-80C1F41E2B9A}"
 EndProject
@@ -27,6 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".files", ".files", "{557A45
 		codemaid.config = codemaid.config
 		Directory.Build.props = Directory.Build.props
 		LICENSE = LICENSE
+		nuget.config = nuget.config
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/src/SourceCode.Chasm.Repository.AzureTable/AzureTableChasmRepo.CommitRef.cs
+++ b/src/SourceCode.Chasm.Repository.AzureTable/AzureTableChasmRepo.CommitRef.cs
@@ -54,7 +54,7 @@ namespace SourceCode.Chasm.IO.AzureTable
             var refsTable = _refsTable.Value;
             var query = DataEntity.BuildListQuery();
 
-            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var names = new HashSet<string>(StringComparer.Ordinal);
 
             TableContinuationToken token = null;
             do

--- a/src/SourceCode.Chasm.Serializer.Json/SourceCode.Chasm.Serializer.Json.csproj
+++ b/src/SourceCode.Chasm.Serializer.Json/SourceCode.Chasm.Serializer.Json.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00292" />
+    <PackageReference Include="SourceCode.Clay.Json" Version="1.0.0-preview1-00293" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Chasm/Audit.cs
+++ b/src/SourceCode.Chasm/Audit.cs
@@ -72,12 +72,10 @@ namespace SourceCode.Chasm
 
         public override int GetHashCode()
         {
-            var hc = new HashCode();
+            var hc = HashCode.Combine(Name ?? string.Empty, StringComparer.Ordinal);
+            hc = HashCode.Combine(hc, Timestamp);
 
-            hc.Add(Name ?? string.Empty, StringComparer.Ordinal);
-            hc.Add(Timestamp);
-
-            return hc.ToHashCode();
+            return hc;
         }
 
         #endregion

--- a/src/SourceCode.Chasm/BlobIdComparer.cs
+++ b/src/SourceCode.Chasm/BlobIdComparer.cs
@@ -51,13 +51,6 @@ namespace SourceCode.Chasm
 
         private sealed class DefaultComparer : BlobIdComparer
         {
-            #region Constructors
-
-            internal DefaultComparer()
-            { }
-
-            #endregion
-
             #region Methods
 
             public override int Compare(BlobId x, BlobId y) => Sha1Comparer.Default.Compare(x.Sha1, y.Sha1);

--- a/src/SourceCode.Chasm/CommitComparer.cs
+++ b/src/SourceCode.Chasm/CommitComparer.cs
@@ -47,13 +47,6 @@ namespace SourceCode.Chasm
 
         private sealed class DefaultComparer : CommitComparer
         {
-            #region Constructors
-
-            internal DefaultComparer()
-            { }
-
-            #endregion
-
             #region Methods
 
             public override bool Equals(Commit x, Commit y)

--- a/src/SourceCode.Chasm/CommitComparer.cs
+++ b/src/SourceCode.Chasm/CommitComparer.cs
@@ -62,15 +62,11 @@ namespace SourceCode.Chasm
 
             public override int GetHashCode(Commit obj)
             {
-                var hc = new HashCode();
+                var hc = HashCode.Combine(obj.TreeId ?? default, TreeIdComparer.Default);
+                hc = HashCode.Combine(hc, obj.Author, obj.Committer, obj.Parents == null ? 0 : obj.Parents.Count);
+                hc = HashCode.Combine(hc, obj.Message ?? string.Empty, StringComparer.Ordinal);
 
-                hc.Add(obj.TreeId ?? default, TreeIdComparer.Default);
-                hc.Add(obj.Author);
-                hc.Add(obj.Committer);
-                hc.Add(obj.Parents == null ? 0 : obj.Parents.Count);
-                hc.Add(obj.Message ?? string.Empty, StringComparer.Ordinal);
-
-                return hc.ToHashCode();
+                return hc;
             }
 
             #endregion

--- a/src/SourceCode.Chasm/CommitIdComparer.cs
+++ b/src/SourceCode.Chasm/CommitIdComparer.cs
@@ -51,13 +51,6 @@ namespace SourceCode.Chasm
 
         private sealed class DefaultComparer : CommitIdComparer
         {
-            #region Constructors
-
-            internal DefaultComparer()
-            { }
-
-            #endregion
-
             #region Methods
 
             public override int Compare(CommitId x, CommitId y) => Sha1Comparer.Default.Compare(x.Sha1, y.Sha1);

--- a/src/SourceCode.Chasm/CommitRef.cs
+++ b/src/SourceCode.Chasm/CommitRef.cs
@@ -62,12 +62,10 @@ namespace SourceCode.Chasm
 
         public override int GetHashCode()
         {
-            var hc = new HashCode();
+            var hc = HashCode.Combine(CommitId);
+            hc = HashCode.Combine(hc, Branch ?? string.Empty, StringComparer.Ordinal);
 
-            hc.Add(CommitId, CommitIdComparer.Default);
-            hc.Add(Branch ?? string.Empty, StringComparer.Ordinal);
-
-            return hc.ToHashCode();
+            return hc;
         }
 
         #endregion

--- a/src/SourceCode.Chasm/Sha1Comparer.cs
+++ b/src/SourceCode.Chasm/Sha1Comparer.cs
@@ -52,13 +52,6 @@ namespace SourceCode.Chasm
 
         private sealed class DefaultComparer : Sha1Comparer
         {
-            #region Constructors
-
-            internal DefaultComparer()
-            { }
-
-            #endregion
-
             #region Methods
 
             public override int Compare(Sha1 x, Sha1 y)

--- a/src/SourceCode.Chasm/SourceCode.Chasm.csproj
+++ b/src/SourceCode.Chasm/SourceCode.Chasm.csproj
@@ -14,10 +14,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00292" />
-    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00292" />
-    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00292" />
-    <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00292" />
+    <PackageReference Include="SourceCode.Clay" Version="1.0.0-preview1-00293" />
+    <PackageReference Include="SourceCode.Clay.Buffers" Version="1.0.0-preview1-00293" />
+    <PackageReference Include="SourceCode.Clay.Collections" Version="1.0.0-preview1-00293" />
+    <PackageReference Include="SourceCode.Clay.Threading" Version="1.0.0-preview1-00293" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/SourceCode.Chasm/TreeIdComparer.cs
+++ b/src/SourceCode.Chasm/TreeIdComparer.cs
@@ -51,13 +51,6 @@ namespace SourceCode.Chasm
 
         private sealed class DefaultComparer : TreeIdComparer
         {
-            #region Constructors
-
-            internal DefaultComparer()
-            { }
-
-            #endregion
-
             #region Methods
 
             public override int Compare(TreeId x, TreeId y) => Sha1Comparer.Default.Compare(x.Sha1, y.Sha1);

--- a/src/SourceCode.Chasm/TreeNodeComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeComparer.cs
@@ -23,6 +23,11 @@ namespace SourceCode.Chasm
         /// </summary>
         public static TreeNodeComparer Default { get; } = new DefaultComparer();
 
+        /// <summary>
+        /// Gets a <see cref="TreeNodeComparer"/> that only compares the <see cref="TreeNode.Name"/> field of a <see cref="TreeNode"/> value.
+        /// </summary>
+        public static TreeNodeComparer NameOnly { get; } = new NameOnlyComparer();
+
         #endregion
 
         #region Constructors
@@ -81,14 +86,24 @@ namespace SourceCode.Chasm
 
             public override int GetHashCode(TreeNode obj)
             {
-                var hc = new HashCode();
+                var hc = HashCode.Combine(obj.Name ?? string.Empty, StringComparer.Ordinal);
+                hc = HashCode.Combine(hc, obj.Kind, obj.Sha1);
 
-                hc.Add(obj.Name ?? string.Empty, StringComparer.Ordinal);
-                hc.Add((int)obj.Kind);
-                hc.Add(obj.Sha1, Sha1Comparer.Default);
-
-                return hc.ToHashCode();
+                return hc;
             }
+
+            #endregion
+        }
+
+        private sealed class NameOnlyComparer : TreeNodeComparer
+        {
+            #region Methods
+
+            public override int Compare(TreeNode x, TreeNode y) => string.CompareOrdinal(x.Name, y.Name);
+
+            public override bool Equals(TreeNode x, TreeNode y) => StringComparer.Ordinal.Equals(x.Name, y.Name);
+
+            public override int GetHashCode(TreeNode obj) => HashCode.Combine(obj.Name ?? string.Empty, StringComparer.Ordinal);
 
             #endregion
         }

--- a/src/SourceCode.Chasm/TreeNodeComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeComparer.cs
@@ -53,13 +53,6 @@ namespace SourceCode.Chasm
 
         private sealed class DefaultComparer : TreeNodeComparer
         {
-            #region Constructors
-
-            internal DefaultComparer()
-            { }
-
-            #endregion
-
             #region Methods
 
             public override int Compare(TreeNode x, TreeNode y)

--- a/src/SourceCode.Chasm/TreeNodeMap.cs
+++ b/src/SourceCode.Chasm/TreeNodeMap.cs
@@ -140,7 +140,7 @@ namespace SourceCode.Chasm
                 {
                     var a = first[aIndex];
                     var b = second[bIndex];
-                    var cmp = StringComparer.Ordinal.Compare(a.Name, b.Name);
+                    var cmp = string.CompareOrdinal(a.Name, b.Name);
 
                     if (cmp == 0)
                     {
@@ -279,7 +279,7 @@ namespace SourceCode.Chasm
 
             while (r >= l)
             {
-                var cmp = StringComparer.Ordinal.Compare(span[i].Name, ks);
+                var cmp = string.CompareOrdinal(span[i].Name, ks);
                 if (cmp == 0) return i;
                 else if (cmp > 0) r = i - 1;
                 else l = i + 1;
@@ -310,7 +310,7 @@ namespace SourceCode.Chasm
             {
                 value = span[i];
 
-                var cmp = StringComparer.Ordinal.Compare(value.Name, ks);
+                var cmp = string.CompareOrdinal(value.Name, ks);
                 if (cmp == 0) return true;
 
                 if (cmp > 0) r = i - 1;
@@ -405,6 +405,7 @@ namespace SourceCode.Chasm
                             // If it's a complete duplicate, silently skip
                             if (TreeNodeComparer.Default.Equals(nodes[i - 1], nodes[i]))
                                 continue;
+
                             throw CreateDuplicateException(nodes[0]);
                         }
                         nodes[j++] = nodes[i]; // Increment target index if distinct

--- a/src/SourceCode.Chasm/TreeNodeMapComparer.cs
+++ b/src/SourceCode.Chasm/TreeNodeMapComparer.cs
@@ -46,13 +46,6 @@ namespace SourceCode.Chasm
 
         private sealed class DefaultComparer : TreeNodeMapComparer
         {
-            #region Constructors
-
-            internal DefaultComparer()
-            { }
-
-            #endregion
-
             #region Methods
 
             public override bool Equals(TreeNodeMap x, TreeNodeMap y)


### PR DESCRIPTION
- Latest Nugets
- Normalize idiom for `GetHashCode`
- `string.CompareOrdinal` is called by `StringComparer.Ordinal.Compare` so can be used instead (perf)
